### PR TITLE
Shopsanity Improvements/Bugfixes

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -2623,7 +2623,7 @@ ScrubIdentity Randomizer::IdentifyScrub(s32 sceneNum, s32 actorParams, s32 respa
     return scrubIdentity;
 }
 
-ShopItemIdentity Randomizer::IdentifyShopItem(s32 sceneNum, s32 actorParams) {
+ShopItemIdentity Randomizer::IdentifyShopItem(s32 sceneNum, u8 slotIndex) {
     struct ShopItemIdentity shopItemIdentity;
 
     shopItemIdentity.randomizerCheck = RC_UNKNOWN_CHECK;
@@ -2634,86 +2634,86 @@ ShopItemIdentity Randomizer::IdentifyShopItem(s32 sceneNum, s32 actorParams) {
     switch (sceneNum) {
         case SCENE_SHOP1:
             if (LINK_IS_ADULT) {
-                switch (actorParams) {
-                    case 0x0C:
+                switch (slotIndex) {
+                    case 0:
                         shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_KAK_BAZAAR_ITEM_1;
                         shopItemIdentity.randomizerCheck = RC_KAK_BAZAAR_ITEM_1;
                         shopItemIdentity.ogItemId = GI_SHIELD_HYLIAN;
                         break;
-                    case 0x2F:
+                    case 1:
                         shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_KAK_BAZAAR_ITEM_2;
                         shopItemIdentity.randomizerCheck = RC_KAK_BAZAAR_ITEM_2;
                         shopItemIdentity.ogItemId = GI_BOMBS_5;
                         break;
-                    case 0x00:
+                    case 2:
                         shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_KAK_BAZAAR_ITEM_3;
                         shopItemIdentity.randomizerCheck = RC_KAK_BAZAAR_ITEM_3;
                         shopItemIdentity.ogItemId = GI_NUTS_5_2;
                         break;
-                    case 0x10:
+                    case 3:
                         shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_KAK_BAZAAR_ITEM_4;
                         shopItemIdentity.randomizerCheck = RC_KAK_BAZAAR_ITEM_4;
                         shopItemIdentity.ogItemId = GI_HEART;
                         break;
-                    case 0x2C:
+                    case 4:
                         shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_KAK_BAZAAR_ITEM_5;
                         shopItemIdentity.randomizerCheck = RC_KAK_BAZAAR_ITEM_5;
                         shopItemIdentity.ogItemId = GI_ARROWS_SMALL;
                         break;
-                    case 0x02:
+                    case 5:
                         shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_KAK_BAZAAR_ITEM_6;
                         shopItemIdentity.randomizerCheck = RC_KAK_BAZAAR_ITEM_6;
                         shopItemIdentity.ogItemId = GI_ARROWS_LARGE;
                         break;
-                    case 0x05:
+                    case 6:
                         shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_KAK_BAZAAR_ITEM_7;
                         shopItemIdentity.randomizerCheck = RC_KAK_BAZAAR_ITEM_7;
                         shopItemIdentity.ogItemId = GI_STICKS_1;
                         break;
-                    case 0x01:
+                    case 7:
                         shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_KAK_BAZAAR_ITEM_8;
                         shopItemIdentity.randomizerCheck = RC_KAK_BAZAAR_ITEM_8;
                         shopItemIdentity.ogItemId = GI_ARROWS_MEDIUM;
                         break;
                 }
             } else {
-                switch (actorParams) {
-                    case 0x0C:
+                switch (slotIndex) {
+                    case 0:
                         shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_MARKET_BAZAAR_ITEM_1;
                         shopItemIdentity.randomizerCheck = RC_MARKET_BAZAAR_ITEM_1;
                         shopItemIdentity.ogItemId = GI_SHIELD_HYLIAN;
                         break;
-                    case 0x2F:
+                    case 1:
                         shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_MARKET_BAZAAR_ITEM_2;
                         shopItemIdentity.randomizerCheck = RC_MARKET_BAZAAR_ITEM_2;
                         shopItemIdentity.ogItemId = GI_BOMBS_5;
                         break;
-                    case 0x00:
+                    case 2:
                         shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_MARKET_BAZAAR_ITEM_3;
                         shopItemIdentity.randomizerCheck = RC_MARKET_BAZAAR_ITEM_3;
                         shopItemIdentity.ogItemId = GI_NUTS_5_2;
                         break;
-                    case 0x10:
+                    case 3:
                         shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_MARKET_BAZAAR_ITEM_4;
                         shopItemIdentity.randomizerCheck = RC_MARKET_BAZAAR_ITEM_4;
                         shopItemIdentity.ogItemId = GI_HEART;
                         break;
-                    case 0x2C:
+                    case 4:
                         shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_MARKET_BAZAAR_ITEM_5;
                         shopItemIdentity.randomizerCheck = RC_MARKET_BAZAAR_ITEM_5;
                         shopItemIdentity.ogItemId = GI_ARROWS_SMALL;
                         break;
-                    case 0x02:
+                    case 5:
                         shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_MARKET_BAZAAR_ITEM_6;
                         shopItemIdentity.randomizerCheck = RC_MARKET_BAZAAR_ITEM_6;
                         shopItemIdentity.ogItemId = GI_ARROWS_LARGE;
                         break;
-                    case 0x05:
+                    case 6:
                         shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_MARKET_BAZAAR_ITEM_7;
                         shopItemIdentity.randomizerCheck = RC_MARKET_BAZAAR_ITEM_7;
                         shopItemIdentity.ogItemId = GI_STICKS_1;
                         break;
-                    case 0x01:
+                    case 7:
                         shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_MARKET_BAZAAR_ITEM_8;
                         shopItemIdentity.randomizerCheck = RC_MARKET_BAZAAR_ITEM_8;
                         shopItemIdentity.ogItemId = GI_ARROWS_MEDIUM;
@@ -2722,43 +2722,43 @@ ShopItemIdentity Randomizer::IdentifyShopItem(s32 sceneNum, s32 actorParams) {
             }
             break;
         case SCENE_KOKIRI_SHOP:
-            switch (actorParams) {
-                case 0x0D:
+            switch (slotIndex) {
+                case 0:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_KF_SHOP_ITEM_1;
                     shopItemIdentity.randomizerCheck = RC_KF_SHOP_ITEM_1;
                     shopItemIdentity.ogItemId = GI_SHIELD_DEKU;
                     break;
-                case 0x00:
+                case 1:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_KF_SHOP_ITEM_2;
                     shopItemIdentity.randomizerCheck = RC_KF_SHOP_ITEM_2;
                     shopItemIdentity.ogItemId = GI_NUTS_5_2;
                     break;
-                case 0x04:
+                case 2:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_KF_SHOP_ITEM_3;
                     shopItemIdentity.randomizerCheck = RC_KF_SHOP_ITEM_3;
                     shopItemIdentity.ogItemId = GI_NUTS_10;
                     break;
-                case 0x05:
+                case 3:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_KF_SHOP_ITEM_4;
                     shopItemIdentity.randomizerCheck = RC_KF_SHOP_ITEM_4;
                     shopItemIdentity.ogItemId = GI_STICKS_1;
                     break;
-                case 0x1D:
+                case 4:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_KF_SHOP_ITEM_5;
                     shopItemIdentity.randomizerCheck = RC_KF_SHOP_ITEM_5;
                     shopItemIdentity.ogItemId = GI_SEEDS_30;
                     break;
-                case 0x2C:
+                case 5:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_KF_SHOP_ITEM_6;
                     shopItemIdentity.randomizerCheck = RC_KF_SHOP_ITEM_6;
                     shopItemIdentity.ogItemId = GI_ARROWS_SMALL;
                     break;
-                case 0x01:
+                case 6:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_KF_SHOP_ITEM_7;
                     shopItemIdentity.randomizerCheck = RC_KF_SHOP_ITEM_7;
                     shopItemIdentity.ogItemId = GI_ARROWS_MEDIUM;
                     break;
-                case 0x10:
+                case 7:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_KF_SHOP_ITEM_8;
                     shopItemIdentity.randomizerCheck = RC_KF_SHOP_ITEM_8;
                     shopItemIdentity.ogItemId = GI_HEART;
@@ -2766,88 +2766,87 @@ ShopItemIdentity Randomizer::IdentifyShopItem(s32 sceneNum, s32 actorParams) {
             }
             break;
         case SCENE_GOLON:
-            switch (actorParams) {
-                case 0x03:
+            switch (slotIndex) {
+                case 0:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_GC_SHOP_ITEM_1;
                     shopItemIdentity.randomizerCheck = RC_GC_SHOP_ITEM_1;
                     shopItemIdentity.ogItemId = GI_BOMBS_5;
                     break;
-                case 0x06:
+                case 1:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_GC_SHOP_ITEM_2;
                     shopItemIdentity.randomizerCheck = RC_GC_SHOP_ITEM_2;
                     shopItemIdentity.ogItemId = GI_BOMBS_10;
                     break;
-                case 0x2D:
+                case 2:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_GC_SHOP_ITEM_3;
                     shopItemIdentity.randomizerCheck = RC_GC_SHOP_ITEM_3;
                     shopItemIdentity.ogItemId = GI_BOMBS_20;
                     break;
-                case 0x2E:
+                case 3:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_GC_SHOP_ITEM_4;
                     shopItemIdentity.randomizerCheck = RC_GC_SHOP_ITEM_4;
                     shopItemIdentity.ogItemId = GI_BOMBS_30;
                     break;
-                case 0x0E:
+                case 4:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_GC_SHOP_ITEM_5;
                     shopItemIdentity.randomizerCheck = RC_GC_SHOP_ITEM_5;
                     shopItemIdentity.ogItemId = GI_TUNIC_GORON;
                     break;
-                case 0x10:
+                case 5:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_GC_SHOP_ITEM_6;
                     shopItemIdentity.randomizerCheck = RC_GC_SHOP_ITEM_6;
                     shopItemIdentity.ogItemId = GI_HEART;
                     break;
-                case 0x30:
+                case 6:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_GC_SHOP_ITEM_7;
                     shopItemIdentity.randomizerCheck = RC_GC_SHOP_ITEM_7;
                     shopItemIdentity.ogItemId = GI_POTION_RED;
                     break;
-                // TODO: Not a huge issue because shopsanity won't use this slot, but it has the same actorParam as another
-                // case 0x10:
-                //     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_GC_SHOP_ITEM_8;
-                //     shopItemIdentity.randomizerCheck = RC_GC_SHOP_ITEM_8;
-                //     shopItemIdentity.ogItemId = GI_HEART;
-                //     break;
+                case 7:
+                    shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_GC_SHOP_ITEM_8;
+                    shopItemIdentity.randomizerCheck = RC_GC_SHOP_ITEM_8;
+                    shopItemIdentity.ogItemId = GI_HEART;
+                    break;
             }
             break;
         case SCENE_ZOORA:
-            switch (actorParams) {
-                case 0x0F:
+            switch (slotIndex) {
+                case 0:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_ZD_SHOP_ITEM_1;
                     shopItemIdentity.randomizerCheck = RC_ZD_SHOP_ITEM_1;
                     shopItemIdentity.ogItemId = GI_TUNIC_ZORA;
                     break;
-                case 0x2C:
+                case 1:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_ZD_SHOP_ITEM_2;
                     shopItemIdentity.randomizerCheck = RC_ZD_SHOP_ITEM_2;
                     shopItemIdentity.ogItemId = GI_ARROWS_SMALL;
                     break;
-                case 0x10:
+                case 2:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_ZD_SHOP_ITEM_3;
                     shopItemIdentity.randomizerCheck = RC_ZD_SHOP_ITEM_3;
                     shopItemIdentity.ogItemId = GI_HEART;
                     break;
-                case 0x01:
+                case 3:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_ZD_SHOP_ITEM_4;
                     shopItemIdentity.randomizerCheck = RC_ZD_SHOP_ITEM_4;
                     shopItemIdentity.ogItemId = GI_ARROWS_MEDIUM;
                     break;
-                case 0x00:
+                case 4:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_ZD_SHOP_ITEM_5;
                     shopItemIdentity.randomizerCheck = RC_ZD_SHOP_ITEM_5;
                     shopItemIdentity.ogItemId = GI_NUTS_5_2;
                     break;
-                case 0x02:
+                case 5:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_ZD_SHOP_ITEM_6;
                     shopItemIdentity.randomizerCheck = RC_ZD_SHOP_ITEM_6;
                     shopItemIdentity.ogItemId = GI_ARROWS_LARGE;
                     break;
-                case 0x07:
+                case 6:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_ZD_SHOP_ITEM_7;
                     shopItemIdentity.randomizerCheck = RC_ZD_SHOP_ITEM_7;
                     shopItemIdentity.ogItemId = GI_FISH;
                     break;
-                case 0x31:
+                case 7:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_ZD_SHOP_ITEM_8;
                     shopItemIdentity.randomizerCheck = RC_ZD_SHOP_ITEM_8;
                     shopItemIdentity.ogItemId = GI_POTION_RED;
@@ -2855,43 +2854,43 @@ ShopItemIdentity Randomizer::IdentifyShopItem(s32 sceneNum, s32 actorParams) {
             }
             break;
         case SCENE_DRAG:
-            switch (actorParams) {
-                case 0x09:
+            switch (slotIndex) {
+                case 0:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_KAK_POTION_SHOP_ITEM_1;
                     shopItemIdentity.randomizerCheck = RC_KAK_POTION_SHOP_ITEM_1;
                     shopItemIdentity.ogItemId = GI_POTION_GREEN;
                     break;
-                case 0x27:
+                case 1:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_KAK_POTION_SHOP_ITEM_2;
                     shopItemIdentity.randomizerCheck = RC_KAK_POTION_SHOP_ITEM_2;
                     shopItemIdentity.ogItemId = GI_BLUE_FIRE;
                     break;
-                case 0x08:
+                case 2:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_KAK_POTION_SHOP_ITEM_3;
                     shopItemIdentity.randomizerCheck = RC_KAK_POTION_SHOP_ITEM_3;
                     shopItemIdentity.ogItemId = GI_POTION_RED;
                     break;
-                case 0x2B:
+                case 3:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_KAK_POTION_SHOP_ITEM_4;
                     shopItemIdentity.randomizerCheck = RC_KAK_POTION_SHOP_ITEM_4;
                     shopItemIdentity.ogItemId = GI_FAIRY;
                     break;
-                case 0x00:
+                case 4:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_KAK_POTION_SHOP_ITEM_5;
                     shopItemIdentity.randomizerCheck = RC_KAK_POTION_SHOP_ITEM_5;
                     shopItemIdentity.ogItemId = GI_NUTS_5_2;
                     break;
-                case 0x28:
+                case 5:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_KAK_POTION_SHOP_ITEM_6;
                     shopItemIdentity.randomizerCheck = RC_KAK_POTION_SHOP_ITEM_6;
                     shopItemIdentity.ogItemId = GI_BUGS;
                     break;
-                case 0x2A:
+                case 6:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_KAK_POTION_SHOP_ITEM_7;
                     shopItemIdentity.randomizerCheck = RC_KAK_POTION_SHOP_ITEM_7;
                     shopItemIdentity.ogItemId = GI_POE;
                     break;
-                case 0x07:
+                case 7:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_KAK_POTION_SHOP_ITEM_8;
                     shopItemIdentity.randomizerCheck = RC_KAK_POTION_SHOP_ITEM_8;
                     shopItemIdentity.ogItemId = GI_FISH;
@@ -2899,43 +2898,43 @@ ShopItemIdentity Randomizer::IdentifyShopItem(s32 sceneNum, s32 actorParams) {
             }
             break;
         case SCENE_ALLEY_SHOP:
-            switch (actorParams) {
-                case 0x09:
+            switch (slotIndex) {
+                case 0:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_MARKET_POTION_SHOP_ITEM_1;
                     shopItemIdentity.randomizerCheck = RC_MARKET_POTION_SHOP_ITEM_1;
                     shopItemIdentity.ogItemId = GI_POTION_GREEN;
                     break;
-                case 0x27:
+                case 1:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_MARKET_POTION_SHOP_ITEM_2;
                     shopItemIdentity.randomizerCheck = RC_MARKET_POTION_SHOP_ITEM_2;
                     shopItemIdentity.ogItemId = GI_BLUE_FIRE;
                     break;
-                case 0x08:
+                case 2:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_MARKET_POTION_SHOP_ITEM_3;
                     shopItemIdentity.randomizerCheck = RC_MARKET_POTION_SHOP_ITEM_3;
                     shopItemIdentity.ogItemId = GI_POTION_RED;
                     break;
-                case 0x2B:
+                case 3:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_MARKET_POTION_SHOP_ITEM_4;
                     shopItemIdentity.randomizerCheck = RC_MARKET_POTION_SHOP_ITEM_4;
                     shopItemIdentity.ogItemId = GI_FAIRY;
                     break;
-                case 0x00:
+                case 4:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_MARKET_POTION_SHOP_ITEM_5;
                     shopItemIdentity.randomizerCheck = RC_MARKET_POTION_SHOP_ITEM_5;
                     shopItemIdentity.ogItemId = GI_NUTS_5_2;
                     break;
-                case 0x28:
+                case 5:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_MARKET_POTION_SHOP_ITEM_6;
                     shopItemIdentity.randomizerCheck = RC_MARKET_POTION_SHOP_ITEM_6;
                     shopItemIdentity.ogItemId = GI_BUGS;
                     break;
-                case 0x2A:
+                case 6:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_MARKET_POTION_SHOP_ITEM_7;
                     shopItemIdentity.randomizerCheck = RC_MARKET_POTION_SHOP_ITEM_7;
                     shopItemIdentity.ogItemId = GI_POE;
                     break;
-                case 0x07:
+                case 7:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_MARKET_POTION_SHOP_ITEM_8;
                     shopItemIdentity.randomizerCheck = RC_MARKET_POTION_SHOP_ITEM_8;
                     shopItemIdentity.ogItemId = GI_FISH;
@@ -2943,43 +2942,43 @@ ShopItemIdentity Randomizer::IdentifyShopItem(s32 sceneNum, s32 actorParams) {
             }
             break;
         case SCENE_NIGHT_SHOP:
-            switch (actorParams) {
-                case 0x18:
+            switch (slotIndex) {
+                case 0:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_MARKET_BOMBCHU_SHOP_ITEM_1;
                     shopItemIdentity.randomizerCheck = RC_MARKET_BOMBCHU_SHOP_ITEM_1;
                     shopItemIdentity.ogItemId = GI_BOMBCHUS_10;
                     break;
-                case 0x1C:
+                case 1:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_MARKET_BOMBCHU_SHOP_ITEM_2;
                     shopItemIdentity.randomizerCheck = RC_MARKET_BOMBCHU_SHOP_ITEM_2;
                     shopItemIdentity.ogItemId = GI_BOMBCHUS_10;
                     break;
-                case 0x19:
+                case 2:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_MARKET_BOMBCHU_SHOP_ITEM_3;
                     shopItemIdentity.randomizerCheck = RC_MARKET_BOMBCHU_SHOP_ITEM_3;
                     shopItemIdentity.ogItemId = GI_BOMBCHUS_10;
                     break;
-                case 0x15:
+                case 3:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_MARKET_BOMBCHU_SHOP_ITEM_4;
                     shopItemIdentity.randomizerCheck = RC_MARKET_BOMBCHU_SHOP_ITEM_4;
                     shopItemIdentity.ogItemId = GI_BOMBCHUS_10;
                     break;
-                case 0x1A:
+                case 4:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_MARKET_BOMBCHU_SHOP_ITEM_5;
                     shopItemIdentity.randomizerCheck = RC_MARKET_BOMBCHU_SHOP_ITEM_5;
                     shopItemIdentity.ogItemId = GI_BOMBCHUS_20;
                     break;
-                case 0x16:
+                case 5:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_MARKET_BOMBCHU_SHOP_ITEM_6;
                     shopItemIdentity.randomizerCheck = RC_MARKET_BOMBCHU_SHOP_ITEM_6;
                     shopItemIdentity.ogItemId = GI_BOMBCHUS_20;
                     break;
-                case 0x1B:
+                case 6:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_MARKET_BOMBCHU_SHOP_ITEM_7;
                     shopItemIdentity.randomizerCheck = RC_MARKET_BOMBCHU_SHOP_ITEM_7;
                     shopItemIdentity.ogItemId = GI_BOMBCHUS_20;
                     break;
-                case 0x17:
+                case 7:
                     shopItemIdentity.randomizerInf = RAND_INF_SHOP_ITEMS_MARKET_BOMBCHU_SHOP_ITEM_8;
                     shopItemIdentity.randomizerCheck = RC_MARKET_BOMBCHU_SHOP_ITEM_8;
                     shopItemIdentity.ogItemId = GI_BOMBCHUS_20;

--- a/soh/soh/Enhancements/randomizer/randomizer.h
+++ b/soh/soh/Enhancements/randomizer/randomizer.h
@@ -57,7 +57,7 @@ class Randomizer {
     std::string GetGanonText() const;
     std::string GetGanonHintText() const;
     ScrubIdentity IdentifyScrub(s32 sceneNum, s32 actorParams, s32 respawnData);
-    ShopItemIdentity IdentifyShopItem(s32 sceneNum, s32 actorParams);
+    ShopItemIdentity IdentifyShopItem(s32 sceneNum, u8 slotIndex);
     GetItemID GetItemIdFromKnownCheck(RandomizerCheck randomizerCheck, GetItemID ogItemId);
     GetItemID GetItemIdFromActor(s16 actorId, s16 sceneNum, s16 actorParams, GetItemID ogItemId);
     GetItemID GetItemIdFromRandomizerGet(RandomizerGet randoGet, GetItemID ogItemId);

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1599,8 +1599,8 @@ extern "C" ScrubIdentity Randomizer_IdentifyScrub(s32 sceneNum, s32 actorParams,
     return OTRGlobals::Instance->gRandomizer->IdentifyScrub(sceneNum, actorParams, respawnData);
 }
 
-extern "C" ShopItemIdentity Randomizer_IdentifyShopItem(s32 sceneNum, s32 actorParams) {
-    return OTRGlobals::Instance->gRandomizer->IdentifyShopItem(sceneNum, actorParams);
+extern "C" ShopItemIdentity Randomizer_IdentifyShopItem(s32 sceneNum, u8 slotIndex) {
+    return OTRGlobals::Instance->gRandomizer->IdentifyShopItem(sceneNum, slotIndex);
 }
 
 extern "C" CustomMessageEntry Randomizer_GetScrubMessage(s16 itemPrice) {

--- a/soh/soh/OTRGlobals.h
+++ b/soh/soh/OTRGlobals.h
@@ -98,7 +98,7 @@ void Randomizer_LoadSettings(const char* spoilerFileName);
 u8 Randomizer_GetSettingValue(RandomizerSettingKey randoSettingKey);
 RandomizerCheck Randomizer_GetCheckFromActor(s16 actorId, s16 sceneNum, s16 actorParams);
 ScrubIdentity Randomizer_IdentifyScrub(s32 sceneNum, s32 actorParams, s32 respawnData);
-ShopItemIdentity Randomizer_IdentifyShopItem(s32 sceneNum, s32 actorParams);
+ShopItemIdentity Randomizer_IdentifyShopItem(s32 sceneNum, u8 slotIndex);
 void Randomizer_LoadHintLocations(const char* spoilerFileName);
 void Randomizer_LoadMerchantMessages(const char* spoilerFileName);
 void Randomizer_LoadRequiredTrials(const char* spoilerFileName);

--- a/soh/src/overlays/actors/ovl_En_GirlA/z_en_girla.c
+++ b/soh/src/overlays/actors/ovl_En_GirlA/z_en_girla.c
@@ -391,7 +391,7 @@ void EnGirlA_InitItem(EnGirlA* this, GlobalContext* globalCtx) {
     if (!gSaveContext.n64ddFlag || !Randomizer_GetSettingValue(RSK_SHOPSANITY)) {
         this->objBankIndex = Object_GetIndex(&globalCtx->objectCtx, shopItemEntries[params].objID);
     } else {
-        ShopItemIdentity shopItemIdentity = Randomizer_IdentifyShopItem(globalCtx->sceneNum, this->actor.params);
+        ShopItemIdentity shopItemIdentity = Randomizer_IdentifyShopItem(globalCtx->sceneNum, this->randoSlotIndex);
         s16 objectId = shopItemEntries[params].objID;
 
         if (shopItemIdentity.randomizerCheck != RC_UNKNOWN_CHECK) {
@@ -744,7 +744,7 @@ s32 EnGirlA_CanBuy_Fairy(GlobalContext* globalCtx, EnGirlA* this) {
 }
 
 s32 EnGirlA_CanBuy_Randomizer(GlobalContext* globalCtx, EnGirlA* this) {
-    ShopItemIdentity shopItemIdentity = Randomizer_IdentifyShopItem(globalCtx->sceneNum, this->actor.params);
+    ShopItemIdentity shopItemIdentity = Randomizer_IdentifyShopItem(globalCtx->sceneNum, this->randoSlotIndex);
     GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheckWithoutObtainabilityCheck(shopItemIdentity.randomizerCheck, shopItemIdentity.ogItemId);
     ItemObtainability itemObtainability = Randomizer_GetItemObtainabilityFromRandomizerCheck(shopItemIdentity.randomizerCheck);
 
@@ -902,7 +902,7 @@ void EnGirlA_ItemGive_BottledItem(GlobalContext* globalCtx, EnGirlA* this) {
 
 // This is called when EnGirlA_CanBuy_Randomizer returns CANBUY_RESULT_SUCCESS
 void EnGirlA_ItemGive_Randomizer(GlobalContext* globalCtx, EnGirlA* this) {
-    ShopItemIdentity shopItemIdentity = Randomizer_IdentifyShopItem(globalCtx->sceneNum, this->actor.params);
+    ShopItemIdentity shopItemIdentity = Randomizer_IdentifyShopItem(globalCtx->sceneNum, this->randoSlotIndex);
     GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheckWithoutObtainabilityCheck(shopItemIdentity.randomizerCheck, shopItemIdentity.ogItemId);
 
     if (getItemEntry.modIndex == MOD_NONE) {
@@ -972,7 +972,7 @@ void EnGirlA_BuyEvent_ObtainBombchuPack(GlobalContext* globalCtx, EnGirlA* this)
 
 // This is called when EnGirlA_CanBuy_Randomizer returns CANBUY_RESULT_SUCCESS_FANFARE
 void EnGirlA_BuyEvent_Randomizer(GlobalContext* globalCtx, EnGirlA* this) {
-    ShopItemIdentity shopItemIdentity = Randomizer_IdentifyShopItem(globalCtx->sceneNum, this->actor.params);
+    ShopItemIdentity shopItemIdentity = Randomizer_IdentifyShopItem(globalCtx->sceneNum, this->randoSlotIndex);
     Flags_SetRandomizerInf(shopItemIdentity.randomizerInf);
     Rupees_ChangeBy(-this->basePrice);
 }
@@ -1026,7 +1026,7 @@ void EnGirlA_SetItemDescription(GlobalContext* globalCtx, EnGirlA* this) {
     }
 
     if (gSaveContext.n64ddFlag && Randomizer_GetSettingValue(RSK_SHOPSANITY)) {
-        ShopItemIdentity shopItemIdentity = Randomizer_IdentifyShopItem(globalCtx->sceneNum, this->actor.params);
+        ShopItemIdentity shopItemIdentity = Randomizer_IdentifyShopItem(globalCtx->sceneNum, this->randoSlotIndex);
         if (shopItemIdentity.randomizerCheck != RC_UNKNOWN_CHECK) {
             if  (shopItemIdentity.enGirlAShopItem == -1) {
                 this->actor.textId = 0x9100 + (shopItemIdentity.randomizerInf - RAND_INF_SHOP_ITEMS_KF_SHOP_ITEM_1);
@@ -1056,7 +1056,7 @@ void EnGirlA_UpdateStockedItem(GlobalContext* globalCtx, EnGirlA* this) {
         itemEntry = &shopItemEntries[this->actor.params];
 
         if (gSaveContext.n64ddFlag && Randomizer_GetSettingValue(RSK_SHOPSANITY)) {
-            ShopItemIdentity shopItemIdentity = Randomizer_IdentifyShopItem(globalCtx->sceneNum, this->actor.params);
+            ShopItemIdentity shopItemIdentity = Randomizer_IdentifyShopItem(globalCtx->sceneNum, this->randoSlotIndex);
             if (shopItemIdentity.randomizerCheck != RC_UNKNOWN_CHECK) {
                 if (shopItemIdentity.enGirlAShopItem == -1) {
                     itemEntry->itemDescTextId = 0x9100 + (shopItemIdentity.randomizerInf - RAND_INF_SHOP_ITEMS_KF_SHOP_ITEM_1);
@@ -1190,7 +1190,7 @@ void EnGirlA_InitializeItemAction(EnGirlA* this, GlobalContext* globalCtx) {
 
         // TODO: This is pretty verbose, pointers are making this difficult
         if (gSaveContext.n64ddFlag && Randomizer_GetSettingValue(RSK_SHOPSANITY)) {
-            ShopItemIdentity shopItemIdentity = Randomizer_IdentifyShopItem(globalCtx->sceneNum, this->actor.params);
+            ShopItemIdentity shopItemIdentity = Randomizer_IdentifyShopItem(globalCtx->sceneNum, this->randoSlotIndex);
             if (shopItemIdentity.randomizerCheck != RC_UNKNOWN_CHECK) {
                 if (shopItemIdentity.enGirlAShopItem == -1) {
                     GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheckWithoutObtainabilityCheck(shopItemIdentity.randomizerCheck, shopItemIdentity.ogItemId);

--- a/soh/src/overlays/actors/ovl_En_GirlA/z_en_girla.c
+++ b/soh/src/overlays/actors/ovl_En_GirlA/z_en_girla.c
@@ -1206,7 +1206,7 @@ void EnGirlA_InitializeItemAction(EnGirlA* this, GlobalContext* globalCtx) {
         this->yRotation = 0;
         this->yRotationInit = this->actor.shape.rot.y;
 
-        if (gSaveContext.n64ddFlag && Randomizer_GetSettingValue(RSK_SHOPSANITY)) {
+        if (gSaveContext.n64ddFlag && Randomizer_GetSettingValue(RSK_SHOPSANITY) && params != SI_SOLD_OUT) {
             ShopItemIdentity shopItemIdentity = Randomizer_IdentifyShopItem(globalCtx->sceneNum, this->randoSlotIndex);
             if (shopItemIdentity.randomizerCheck != RC_UNKNOWN_CHECK) {
                 if (shopItemIdentity.enGirlAShopItem == -1) {

--- a/soh/src/overlays/actors/ovl_En_GirlA/z_en_girla.c
+++ b/soh/src/overlays/actors/ovl_En_GirlA/z_en_girla.c
@@ -978,6 +978,7 @@ void EnGirlA_BuyEvent_ObtainBombchuPack(GlobalContext* globalCtx, EnGirlA* this)
 void EnGirlA_BuyEvent_Randomizer(GlobalContext* globalCtx, EnGirlA* this) {
     ShopItemIdentity shopItemIdentity = Randomizer_IdentifyShopItem(globalCtx->sceneNum, this->randoSlotIndex);
     Flags_SetRandomizerInf(shopItemIdentity.randomizerInf);
+    Rupees_ChangeBy(-this->basePrice);
     if (shopItemIdentity.enGirlAShopItem == -1) {
         ShopItemEntry* itemEntry = &shopItemEntries[SI_SOLD_OUT];
         this->actor.textId = itemEntry->itemDescTextId;
@@ -990,7 +991,6 @@ void EnGirlA_BuyEvent_Randomizer(GlobalContext* globalCtx, EnGirlA* this) {
         this->itemCount = itemEntry->count;
         this->giDrawId = itemEntry->giDrawId;
     }
-    Rupees_ChangeBy(-this->basePrice);
 }
 
 void EnGirlA_Noop(EnGirlA* this, GlobalContext* globalCtx) {

--- a/soh/src/overlays/actors/ovl_En_GirlA/z_en_girla.h
+++ b/soh/src/overlays/actors/ovl_En_GirlA/z_en_girla.h
@@ -33,6 +33,7 @@ typedef struct EnGirlA {
     /* 0x01CA */ s16 itemCount;
     /* 0x01CC */ s16 giDrawId;
     /* 0x01D0 */ EnGirlA3Func hiliteFunc;
+    /* 0x01D4 */ u8 randoSlotIndex; // used by randomizer to determine which slot this item is for id purposes.
 } EnGirlA; // size = 0x01D4
 
 typedef enum {

--- a/soh/src/overlays/actors/ovl_En_Ossan/z_en_ossan.c
+++ b/soh/src/overlays/actors/ovl_En_Ossan/z_en_ossan.c
@@ -437,6 +437,9 @@ void EnOssan_SpawnItemsOnShelves(EnOssan* this, GlobalContext* globalCtx, ShopIt
                     shelves->actor.world.pos.y + shopItems->yOffset, shelves->actor.world.pos.z + shopItems->zOffset,
                     shelves->actor.shape.rot.x, shelves->actor.shape.rot.y + sItemShelfRot[i],
                     shelves->actor.shape.rot.z, itemParams);
+                if (gSaveContext.n64ddFlag && Randomizer_GetSettingValue(RSK_SHOPSANITY)) {
+                    this->shelfSlots[i]->randoSlotIndex = i;
+                }
             }
         }
     }
@@ -1333,7 +1336,7 @@ void EnOssan_GiveItemWithFanfare(GlobalContext* globalCtx, EnOssan* this) {
     if (!gSaveContext.n64ddFlag) {
         func_8002F434(&this->actor, globalCtx, this->shelfSlots[this->cursorIndex]->getItemId, 120.0f, 120.0f);
     } else {
-        ShopItemIdentity shopItemIdentity = Randomizer_IdentifyShopItem(globalCtx->sceneNum, this->shelfSlots[this->cursorIndex]->actor.params);
+        ShopItemIdentity shopItemIdentity = Randomizer_IdentifyShopItem(globalCtx->sceneNum, this->cursorIndex);
         if (shopItemIdentity.randomizerCheck != RC_UNKNOWN_CHECK) {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(shopItemIdentity.randomizerCheck, shopItemIdentity.ogItemId);
             GiveItemEntryFromActor(&this->actor, globalCtx, getItemEntry, 120.0f, 120.0f);

--- a/soh/src/overlays/actors/ovl_En_Ossan/z_en_ossan.c
+++ b/soh/src/overlays/actors/ovl_En_Ossan/z_en_ossan.c
@@ -427,6 +427,16 @@ void EnOssan_SpawnItemsOnShelves(EnOssan* this, GlobalContext* globalCtx, ShopIt
             this->shelfSlots[i] = NULL;
         } else {
             itemParams = sShopItemReplaceFunc[shopItems->shopItemIndex](shopItems->shopItemIndex);
+            if (gSaveContext.n64ddFlag && Randomizer_GetSettingValue(RSK_SHOPSANITY)) {
+                ShopItemIdentity shopItemIdentity = Randomizer_IdentifyShopItem(globalCtx->sceneNum, i);
+                if (shopItemIdentity.enGirlAShopItem == -1) {
+                    if (Flags_GetRandomizerInf(shopItemIdentity.randomizerInf)) {
+                        itemParams = SI_SOLD_OUT;
+                    }
+                } else {
+                    itemParams = shopItemIdentity.enGirlAShopItem;
+                }
+            }
 
             if (itemParams < 0) {
                 this->shelfSlots[i] = NULL;
@@ -1678,7 +1688,18 @@ void EnOssan_State_GiveItemWithFanfare(EnOssan* this, GlobalContext* globalCtx, 
         this->stateFlag = OSSAN_STATE_ITEM_PURCHASED;
         return;
     }
-    func_8002F434(&this->actor, globalCtx, this->shelfSlots[this->cursorIndex]->getItemId, 120.0f, 120.0f);
+    if (!gSaveContext.n64ddFlag) {
+        func_8002F434(&this->actor, globalCtx, this->shelfSlots[this->cursorIndex]->getItemId, 120.0f, 120.0f);
+    } else {
+        ShopItemIdentity shopItemIdentity = Randomizer_IdentifyShopItem(globalCtx->sceneNum, this->cursorIndex);
+        if (shopItemIdentity.randomizerCheck != RC_UNKNOWN_CHECK) {
+            GetItemEntry getItemEntry =
+                Randomizer_GetItemFromKnownCheck(shopItemIdentity.randomizerCheck, shopItemIdentity.ogItemId);
+            GiveItemEntryFromActor(&this->actor, globalCtx, getItemEntry, 120.0f, 120.0f);
+        } else {
+            func_8002F434(&this->actor, globalCtx, this->shelfSlots[this->cursorIndex]->getItemId, 120.0f, 120.0f);
+        }
+    }
 }
 
 void EnOssan_State_ItemPurchased(EnOssan* this, GlobalContext* globalCtx, Player* player) {


### PR DESCRIPTION
- Adds `randoSlotIndex` to girla (shop item actor) and uses that for `IdentifyShopItem`.
- Items added to the shop pool from the main rando pool now properly "sell out" and get replaced by a SOLD OUT sign.
- Fixes a few issues with Item Purchases not going through correctly, by not entering your inventory or giving you the wrong item during the fanfare.