### PR TITLE
Assorted Fixes for checks that broke

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -2164,6 +2164,13 @@ RandomizerCheckObject Randomizer::GetCheckObjectFromActor(s16 actorId, s16 scene
                     specialRc = RC_FAIRY_GOSSIP_STONE;
             }
             break;
+        case SCENE_BDAN_BOSS:
+            // If Ruto is in Barinade's blue warp, the actor params are 5 rather than
+            // 0. The multimap has 0, which is accurate if Ruto is not in the blue warp.
+            // Change the actorParams value used for the lookup to 0.
+            if (!(gSaveContext.eventChkInf[3] & 0x80) && actorId == ACTOR_DOOR_WARP1) {
+                actorParams = 0;
+            }
     }
 
     if (specialRc != RC_UNKNOWN_CHECK) {

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -2195,7 +2195,7 @@ ScrubIdentity Randomizer::IdentifyScrub(s32 sceneNum, s32 actorParams, s32 respa
     scrubIdentity.isShuffled = false;
 
     if (sceneNum == SCENE_KAKUSIANA) {
-        actorParams = TWO_ACTOR_PARAMS(actorParams == 0x06 ? 0x03 : actorParams, respawnData);
+        actorParams = TWO_ACTOR_PARAMS((actorParams == 0x06 ? 0x03 : actorParams), respawnData);
     }
 
     RandomizerCheckObject rcObject = GetCheckObjectFromActor(ACTOR_EN_DNS, sceneNum, actorParams);

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -2194,7 +2194,11 @@ ScrubIdentity Randomizer::IdentifyScrub(s32 sceneNum, s32 actorParams, s32 respa
     scrubIdentity.itemPrice = -1;
     scrubIdentity.isShuffled = false;
 
-    RandomizerCheckObject rcObject = GetCheckObjectFromActor(ACTOR_EN_DNS, sceneNum, TWO_ACTOR_PARAMS(actorParams == 0x06 ? 0x03 : actorParams, respawnData));
+    if (sceneNum == SCENE_KAKUSIANA) {
+        actorParams = TWO_ACTOR_PARAMS(actorParams == 0x06 ? 0x03 : actorParams, respawnData);
+    }
+
+    RandomizerCheckObject rcObject = GetCheckObjectFromActor(ACTOR_EN_DNS, sceneNum, actorParams);
 
     if (rcObject.rc != RC_UNKNOWN_CHECK) {
         scrubIdentity.randomizerInf = rcToRandomizerInf[rcObject.rc];


### PR DESCRIPTION
- Only use the `TWO_ACTOR_PARAMS` for Deku Scrubs in Grottos. Fixes all the non-grotto scrubs.
- Ensure the correct lookup occurs for `DMC_DEKU_SCRUB_GROTTO_CENTER` by wrapping the ternary statement in parenthesis.
- Barinade's blue warp has `actorParams` of 5 if Ruto is inside it. The multimap has 0, which is accurate if the blue warp is used without Ruto inside of it somehow. Added a special case to the lookup function that sets the actorParams variable to 0 before doing the lookup.