### PR TITLE
Fix entrance rando in vanilla logic and vanilla option overrides

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/fill.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/fill.cpp
@@ -905,6 +905,8 @@ void VanillaFill() {
     ShuffleAllEntrances();
     printf("\x1b[7;32HDone");
   }
+  // Populate the playthrough for entrances so they are placed in the spoiler log
+  GeneratePlaythrough();
   //Finish up
   CreateItemOverrides();
   CreateEntranceOverrides();

--- a/soh/soh/Enhancements/randomizer/3drando/menu.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/menu.cpp
@@ -517,6 +517,14 @@ void PrintOptionDescription() {
   printf("\x1b[22;0H%s", description.data());
 }
 
+static void RestoreOverrides() {
+    if (Settings::Logic.Is(LOGIC_VANILLA)) {
+        for (auto overridePair : Settings::vanillaLogicOverrides) {
+            overridePair.first->RestoreDelayedOption();
+        }
+    }
+}
+
 std::string GenerateRandomizer(std::unordered_map<RandomizerSettingKey, uint8_t> cvarSettings, std::set<RandomizerCheck> excludedLocations) {
     // if a blank seed was entered, make a random one
     srand(time(NULL));
@@ -528,20 +536,17 @@ std::string GenerateRandomizer(std::unordered_map<RandomizerSettingKey, uint8_t>
             printf("\n\nFailed to generate after 5 tries.\nPress B to go back to the menu.\nA different seed might be "
                    "successful.");
             SPDLOG_DEBUG("\nRANDOMIZATION FAILED COMPLETELY. PLZ FIX\n");
+            RestoreOverrides();
             return "";
         } else {
             printf("\n\nError %d with fill.\nPress Select to exit or B to go back to the menu.\n", ret);
+            RestoreOverrides();
             return "";
         }
     }
 
-    // Restore settings that were set to a specific value for vanilla logic
-    if (Settings::Logic.Is(LOGIC_VANILLA)) {
-        for (Option* setting : Settings::vanillaLogicDefaults) {
-            setting->RestoreDelayedOption();
-        }
-        Settings::Keysanity.RestoreDelayedOption();
-    }
+    RestoreOverrides();
+
     std::ostringstream fileNameStream;
     for (int i = 0; i < Settings::hashIconIndexes.size(); i++) {
         if (i) {

--- a/soh/soh/Enhancements/randomizer/3drando/settings.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/settings.cpp
@@ -2374,18 +2374,20 @@ namespace Settings {
   }
 
   //Options that should be saved, set to default, then restored after finishing when vanilla logic is enabled
-  std::vector<Option *> vanillaLogicDefaults = {
-    &LinksPocketItem,
-    &ShuffleRewards,
-    &ShuffleSongs,
-    &Shopsanity,
-    &Scrubsanity,
-    &ShuffleCows,
-    &ShuffleMagicBeans,
-    &ShuffleMerchants,
-    &ShuffleFrogSongRupees,
-    &ShuffleAdultTradeQuest,
-    &GossipStoneHints,
+  std::vector<std::pair<Option*, uint8_t>> vanillaLogicOverrides = {
+    { &LinksPocketItem, LINKSPOCKETITEM_DUNGEON_REWARD },
+    { &ShuffleRewards, REWARDSHUFFLE_END_OF_DUNGEON },
+    { &ShuffleSongs, SONGSHUFFLE_SONG_LOCATIONS },
+    { &Shopsanity, SHOPSANITY_OFF },
+    { &Scrubsanity, SCRUBSANITY_OFF },
+    { &ShuffleCows, OFF },
+    { &ShuffleMagicBeans, OFF },
+    { &ShuffleMerchants, SHUFFLEMERCHANTS_OFF },
+    { &ShuffleAdultTradeQuest, SHUFFLEADULTTRADEQUEST_ON },
+    { &ShuffleChestMinigame, SHUFFLECHESTMINIGAME_OFF },
+    { &ShuffleFrogSongRupees, SHUFFLEFROGSONGRUPEES_OFF },
+    { &Keysanity, KEYSANITY_ANY_DUNGEON }, // Set small keys to any dungeon so FiT basement door will be locked
+    { &GossipStoneHints, HINTS_NO_HINTS },
   };
 
   // Randomizes all settings in a category if chosen
@@ -2763,6 +2765,13 @@ namespace Settings {
     // RANDOTODO implement chest shuffle with keysanity
     // ShuffleChestMinigame.SetSelectedIndex(cvarSettings[RSK_SHUFFLE_CHEST_MINIGAME]);
 
+    if (Logic.Is(LOGIC_VANILLA)) {
+      for (auto overridePair : vanillaLogicOverrides) {
+        overridePair.first->SetDelayedOption();
+        overridePair.first->SetSelectedIndex(overridePair.second);
+      }
+    }
+
     RandomizeAllSettings(true); //now select any random options instead of just hiding them
 
     //shuffle the dungeons and then set MQ for as many as necessary
@@ -2919,16 +2928,6 @@ namespace Settings {
     }
 
     UpdateCosmetics();
-
-    //If vanilla logic, we want to set all settings which unnecessarily modify vanilla behavior to off
-    if (Logic.Is(LOGIC_VANILLA)) {
-      for (Option* setting : vanillaLogicDefaults) {
-        setting->SetDelayedOption();
-        setting->SetSelectedIndex(0);
-      }
-      Keysanity.SetDelayedOption();
-      Keysanity.SetSelectedIndex(3); //Set small keys to any dungeon so FiT basement door will be locked
-    }
 
     InitMusicRandomizer();
     if (ShuffleMusic) {

--- a/soh/soh/Enhancements/randomizer/3drando/settings.hpp
+++ b/soh/soh/Enhancements/randomizer/3drando/settings.hpp
@@ -167,6 +167,11 @@ typedef enum {
 } ShuffleMerchantsSetting;
 
 typedef enum {
+    SHUFFLEFROGSONGRUPEES_OFF,
+    SHUFFLEFROGSONGRUPEES_ON,
+} ShuffleFrogSongRupeesSetting;
+
+typedef enum {
     SHUFFLEADULTTRADEQUEST_OFF,
     SHUFFLEADULTTRADEQUEST_ON,
 } ShuffleAdultTradeQuestSetting;
@@ -1313,5 +1318,5 @@ void UpdateSettings(std::unordered_map<RandomizerSettingKey, uint8_t> cvarSettin
 
   extern std::vector<Menu *> mainMenu;
 
-  extern std::vector<Option *> vanillaLogicDefaults;
+  extern std::vector<std::pair<Option*, uint8_t>> vanillaLogicOverrides;
 }


### PR DESCRIPTION
Figured out what was missing that was preventing entrance rando from working with vanilla logic.
In 3ds rando, the spoiler log was missing the entrances, but was still correctly overriding the entrances. Our entrance rando relies on the spoiler log logic, so since it was missing, we didn't have the overrides on our end.

Calling `GeneratePlaythrough()` will populate the entrance playthrough list.

Also synced the `vanillaLogicOverrides` with latest 3ds which should correct AdultTrade (will always be turned on).