### PR TITLE
Invert culling for health meter and A button action

### DIFF
--- a/soh/src/code/z_lifemeter.c
+++ b/soh/src/code/z_lifemeter.c
@@ -599,6 +599,12 @@ void HealthMeter_Draw(PlayState* play) {
                 }
             }
 
+            // Invert culling since we are not flipping z_parameter for mirror world
+            if (CVarGetInteger("gMirroredWorld", 0)) {
+                gSPClearGeometryMode(OVERLAY_DISP++, G_CULL_BACK);
+                gSPSetGeometryMode(OVERLAY_DISP++, G_CULL_FRONT);
+            }
+
             {
                 Mtx* matrix = Graph_Alloc(gfxCtx, sizeof(Mtx));
                 Matrix_SetTranslateScaleMtx2(matrix, 

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -5361,7 +5361,8 @@ void Interface_Draw(PlayState* play) {
             Interface_DrawActionButton(play, PosX_BtnA, PosY_BtnA);
         }
         gDPPipeSync(OVERLAY_DISP++);
-        gSPSetGeometryMode(OVERLAY_DISP++, G_CULL_BACK);
+        // Invert culling since we are not flipping z_parameter for mirror world
+        gSPSetGeometryMode(OVERLAY_DISP++, CVarGetInteger("gMirroredWorld", 0) ? G_CULL_FRONT : G_CULL_BACK);
         gDPSetCombineLERP(OVERLAY_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0,
                           PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
         gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, interfaceCtx->aAlpha);


### PR DESCRIPTION
Inverts the culling manually (a second time) for the health meter and A button action text as culling is already inverted (the first time) in fast3d.

Ideally a better solution would be to have some kind of dedicated culling inversion command that we can call to fast3d and then set/unset it when in the places we explicit want invert culling.

PRing this for now.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/725499254.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/725499256.zip)
  - [soh-linux-performance.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/725499259.zip)
  - [soh-mac.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/725499262.zip)
  - [soh-switch.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/725499263.zip)
  - [soh-windows.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/725499264.zip)
<!--- section:artifacts:end -->