### PR TITLE
Mirror minimap for Mirror World

### DIFF
--- a/soh/src/code/z_map_exp.c
+++ b/soh/src/code/z_map_exp.c
@@ -632,36 +632,53 @@ void Minimap_DrawCompassIcons(PlayState* play) {
         gDPSetEnvColor(OVERLAY_DISP++, 0, 0, 0, 255);
         gDPSetCombineMode(OVERLAY_DISP++, G_CC_PRIMITIVE, G_CC_PRIMITIVE);
 
+        s16 mapWidth = 0;
+        s16 mapStartPosX = 0;
+        if (play->sceneNum >= SCENE_SPOT00 && play->sceneNum <= SCENE_GANON_TOU) { // Overworld
+            mapStartPosX = R_OW_MINIMAP_X;
+            mapWidth = gMapData->owMinimapWidth[R_MAP_INDEX];
+        } else if (play->sceneNum >= SCENE_YDAN && play->sceneNum <= SCENE_ICE_DOUKUTO) { // Dungeons
+            mapStartPosX = R_DGN_MINIMAP_X;
+            mapWidth = 96;
+        }
+
+        // The compass offset value is a factor of 10 compared to N64 screen pixels and originates in the center of the screen
+        // Compute the additional mirror offset value by normalizing the original offset position
+        // and taking it's distance to the center of the map, duplicating that result and casting back to a factor of 10
+        s16 mirrorOffset = ((mapWidth / 2) - ((R_COMPASS_OFFSET_X / 10) - (mapStartPosX - SCREEN_WIDTH / 2))) * 2 * 10;
+
         tempX = player->actor.world.pos.x;
         tempZ = player->actor.world.pos.z;
-        tempX /= R_COMPASS_SCALE_X;
+        tempX /= R_COMPASS_SCALE_X * (CVarGetInteger("gMirroredWorld", 0) ? -1 : 1);
         tempZ /= R_COMPASS_SCALE_Y;
+
+        s16 tempXOffset = R_COMPASS_OFFSET_X + (CVarGetInteger("gMirroredWorld", 0) ? mirrorOffset : 0);
         if (CVarGetInteger("gMinimapPosType", 0) != 0) {
             if (CVarGetInteger("gMinimapPosType", 0) == 1) {//Anchor Left
                 if (CVarGetInteger("gMinimapUseMargins", 0) != 0) {X_Margins_Minimap = Left_MM_Margin;};
-                    Matrix_Translate(
-                        OTRGetDimensionFromLeftEdge((R_COMPASS_OFFSET_X + (X_Margins_Minimap*10) + tempX + (CVarGetInteger("gMinimapPosX", 0)*10)) / 10.0f),
-                        (R_COMPASS_OFFSET_Y + ((Y_Margins_Minimap*10)*-1) - tempZ + ((CVarGetInteger("gMinimapPosY", 0)*10)*-1)) / 10.0f, 0.0f, MTXMODE_NEW);
+                Matrix_Translate(
+                    OTRGetDimensionFromLeftEdge((tempXOffset + (X_Margins_Minimap*10) + tempX + (CVarGetInteger("gMinimapPosX", 0)*10)) / 10.0f),
+                    (R_COMPASS_OFFSET_Y + ((Y_Margins_Minimap*10)*-1) - tempZ + ((CVarGetInteger("gMinimapPosY", 0)*10)*-1)) / 10.0f, 0.0f, MTXMODE_NEW);
             } else if (CVarGetInteger("gMinimapPosType", 0) == 2) {//Anchor Right
                 if (CVarGetInteger("gMinimapUseMargins", 0) != 0) {X_Margins_Minimap = Right_MM_Margin;};
                 Matrix_Translate(
-                    OTRGetDimensionFromRightEdge((R_COMPASS_OFFSET_X + (X_Margins_Minimap*10) + tempX + (CVarGetInteger("gMinimapPosX", 0)*10)) / 10.0f),
+                    OTRGetDimensionFromRightEdge((tempXOffset + (X_Margins_Minimap*10) + tempX + (CVarGetInteger("gMinimapPosX", 0)*10)) / 10.0f),
                     (R_COMPASS_OFFSET_Y +((Y_Margins_Minimap*10)*-1) - tempZ + ((CVarGetInteger("gMinimapPosY", 0)*10)*-1)) / 10.0f, 0.0f, MTXMODE_NEW);
             } else if (CVarGetInteger("gMinimapPosType", 0) == 3) {//Anchor None
                 Matrix_Translate(
-                    (R_COMPASS_OFFSET_X + tempX + (CVarGetInteger("gMinimapPosX", 0)*10) / 10.0f),
+                    (tempXOffset + tempX + (CVarGetInteger("gMinimapPosX", 0)*10) / 10.0f),
                     (R_COMPASS_OFFSET_Y + ((Y_Margins_Minimap*10)*-1) - tempZ + ((CVarGetInteger("gMinimapPosY", 0)*10)*-1)) / 10.0f, 0.0f, MTXMODE_NEW);
             } else if (CVarGetInteger("gMinimapPosType", 0) == 4) {//Hidden
                 Matrix_Translate(
-                    (R_COMPASS_OFFSET_X+(9999*10) + tempX / 10.0f),
+                    (tempXOffset+(9999*10) + tempX / 10.0f),
                     (R_COMPASS_OFFSET_Y+(9999*10) - tempZ) / 10.0f, 0.0f, MTXMODE_NEW);
             }
         } else {
-            Matrix_Translate(OTRGetDimensionFromRightEdge((R_COMPASS_OFFSET_X+(X_Margins_Minimap*10) + tempX) / 10.0f), (R_COMPASS_OFFSET_Y+((Y_Margins_Minimap*10)*-1) - tempZ) / 10.0f, 0.0f, MTXMODE_NEW);
+            Matrix_Translate(OTRGetDimensionFromRightEdge((tempXOffset+(X_Margins_Minimap*10) + tempX) / 10.0f), (R_COMPASS_OFFSET_Y+((Y_Margins_Minimap*10)*-1) - tempZ) / 10.0f, 0.0f, MTXMODE_NEW);
         }
         Matrix_Scale(0.4f, 0.4f, 0.4f, MTXMODE_APPLY);
         Matrix_RotateX(-1.6f, MTXMODE_APPLY);
-        tempX = (0x7FFF - player->actor.shape.rot.y) / 0x400;
+        tempX = ((0x7FFF - player->actor.shape.rot.y) / 0x400) * (CVarGetInteger("gMirroredWorld", 0) ? -1 : 1);
         Matrix_RotateY(tempX / 10.0f, MTXMODE_APPLY);
         gSPMatrix(OVERLAY_DISP++, MATRIX_NEWMTX(play->state.gfxCtx),
                   G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
@@ -670,36 +687,36 @@ void Minimap_DrawCompassIcons(PlayState* play) {
         gSPDisplayList(OVERLAY_DISP++, gCompassArrowDL);
 
         //Player map entry (red arrow)
-        tempX = sPlayerInitialPosX+X_Margins_Minimap;
-        tempZ = sPlayerInitialPosZ+Y_Margins_Minimap;
-        tempX /= R_COMPASS_SCALE_X;
+        tempX = sPlayerInitialPosX;
+        tempZ = sPlayerInitialPosZ;
+        tempX /= R_COMPASS_SCALE_X * (CVarGetInteger("gMirroredWorld", 0) ? -1 : 1);
         tempZ /= R_COMPASS_SCALE_Y;
         if (CVarGetInteger("gMinimapPosType", 0) != 0) {
             if (CVarGetInteger("gMinimapPosType", 0) == 1) {//Anchor Left
                 if (CVarGetInteger("gMinimapUseMargins", 0) != 0) {X_Margins_Minimap = Left_MM_Margin;};
-                    Matrix_Translate(
-                        OTRGetDimensionFromLeftEdge((R_COMPASS_OFFSET_X + (X_Margins_Minimap*10) + tempX + (CVarGetInteger("gMinimapPosX", 0)*10)) / 10.0f),
-                        (R_COMPASS_OFFSET_Y + ((Y_Margins_Minimap*10)*-1) - tempZ + ((CVarGetInteger("gMinimapPosY", 0)*10)*-1)) / 10.0f, 0.0f, MTXMODE_NEW);
+                Matrix_Translate(
+                    OTRGetDimensionFromLeftEdge((tempXOffset + (X_Margins_Minimap*10) + tempX + (CVarGetInteger("gMinimapPosX", 0)*10)) / 10.0f),
+                    (R_COMPASS_OFFSET_Y + ((Y_Margins_Minimap*10)*-1) - tempZ + ((CVarGetInteger("gMinimapPosY", 0)*10)*-1)) / 10.0f, 0.0f, MTXMODE_NEW);
             } else if (CVarGetInteger("gMinimapPosType", 0) == 2) {//Anchor Right
                 if (CVarGetInteger("gMinimapUseMargins", 0) != 0) {X_Margins_Minimap = Right_MM_Margin;};
                 Matrix_Translate(
-                    OTRGetDimensionFromRightEdge((R_COMPASS_OFFSET_X + (X_Margins_Minimap*10) + tempX + (CVarGetInteger("gMinimapPosX", 0)*10)) / 10.0f),
+                    OTRGetDimensionFromRightEdge((tempXOffset + (X_Margins_Minimap*10) + tempX + (CVarGetInteger("gMinimapPosX", 0)*10)) / 10.0f),
                     (R_COMPASS_OFFSET_Y +((Y_Margins_Minimap*10)*-1) - tempZ + ((CVarGetInteger("gMinimapPosY", 0)*10)*-1)) / 10.0f, 0.0f, MTXMODE_NEW);
             } else if (CVarGetInteger("gMinimapPosType", 0) == 3) {//Anchor None
                 Matrix_Translate(
-                    (R_COMPASS_OFFSET_X + tempX + (CVarGetInteger("gMinimapPosX", 0)*10) / 10.0f),
+                    (tempXOffset + tempX + (CVarGetInteger("gMinimapPosX", 0)*10) / 10.0f),
                     (R_COMPASS_OFFSET_Y - tempZ + ((CVarGetInteger("gMinimapPosY", 0)*10)*-1)) / 10.0f, 0.0f, MTXMODE_NEW);
             } else if (CVarGetInteger("gMinimapPosType", 0) == 4) {//Hidden
                 Matrix_Translate(
-                    (R_COMPASS_OFFSET_X+(9999*10) + tempX / 10.0f),
+                    (tempXOffset+(9999*10) + tempX / 10.0f),
                     (R_COMPASS_OFFSET_Y+(9999*10) - tempZ) / 10.0f, 0.0f, MTXMODE_NEW);
             }
         } else {
-            Matrix_Translate(OTRGetDimensionFromRightEdge((R_COMPASS_OFFSET_X+(X_Margins_Minimap*10) + tempX) / 10.0f), (R_COMPASS_OFFSET_Y+((Y_Margins_Minimap*10)*-1) - tempZ) / 10.0f, 0.0f, MTXMODE_NEW);
+            Matrix_Translate(OTRGetDimensionFromRightEdge((tempXOffset+(X_Margins_Minimap*10) + tempX) / 10.0f), (R_COMPASS_OFFSET_Y+((Y_Margins_Minimap*10)*-1) - tempZ) / 10.0f, 0.0f, MTXMODE_NEW);
         }
         Matrix_Scale(VREG(9) / 100.0f, VREG(9) / 100.0f, VREG(9) / 100.0f, MTXMODE_APPLY);
         Matrix_RotateX(VREG(52) / 10.0f, MTXMODE_APPLY);
-        Matrix_RotateY(sPlayerInitialDirection / 10.0f, MTXMODE_APPLY);
+        Matrix_RotateY((sPlayerInitialDirection * (CVarGetInteger("gMirroredWorld", 0) ? -1 : 1)) / 10.0f, MTXMODE_APPLY);
         gSPMatrix(OVERLAY_DISP++, MATRIX_NEWMTX(play->state.gfxCtx),
                   G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
@@ -757,8 +774,9 @@ void Minimap_Draw(PlayState* play) {
                     if (CHECK_DUNGEON_ITEM(DUNGEON_MAP, mapIndex)) {
                         gDPSetPrimColor(OVERLAY_DISP++, 0, 0, minimapColor.r, minimapColor.g, minimapColor.b, interfaceCtx->minimapAlpha);
 
+                        u8 mirrorMode = CVarGetInteger("gMirroredWorld", 0) ? G_TX_MIRROR : G_TX_NOMIRROR;
                         gDPLoadTextureBlock_4b(OVERLAY_DISP++, interfaceCtx->mapSegmentName[0], G_IM_FMT_I, 96, 85, 0,
-                                               G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK,
+                                               mirrorMode | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK,
                                                G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
 
                         s16 dgnMiniMapX = OTRGetRectDimensionFromRightEdge(R_DGN_MINIMAP_X + X_Margins_Minimap);
@@ -777,9 +795,16 @@ void Minimap_Draw(PlayState* play) {
                                 dgnMiniMapX = -9999;
                             }
                         }
+
+                        s32 sValue = 0;
+                        if (CVarGetInteger("gMirroredWorld", 0)) {
+                            // Flip the minimap on the x-axis (s-axis) by setting s to the textures mirror boundary
+                            sValue = 96 << 5;
+                        }
+
                         gSPWideTextureRectangle(OVERLAY_DISP++, dgnMiniMapX << 2, dgnMiniMapY << 2,
                                             (dgnMiniMapX + 96) << 2, (dgnMiniMapY + 85) << 2, G_TX_RENDERTILE,
-                                            0, 0, 1 << 10, 1 << 10);
+                                            sValue, 0, 1 << 10, 1 << 10);
                     }
 
                     if (CHECK_DUNGEON_ITEM(DUNGEON_COMPASS, mapIndex)) {
@@ -827,9 +852,10 @@ void Minimap_Draw(PlayState* play) {
                     gDPSetCombineMode(OVERLAY_DISP++, G_CC_MODULATEIA_PRIM, G_CC_MODULATEIA_PRIM);
                     gDPSetPrimColor(OVERLAY_DISP++, 0, 0, minimapColor.r, minimapColor.g, minimapColor.b, interfaceCtx->minimapAlpha);
 
+                    u8 mirrorMode = CVarGetInteger("gMirroredWorld", 0) ? G_TX_MIRROR : G_TX_NOMIRROR;
                     gDPLoadTextureBlock_4b(OVERLAY_DISP++, interfaceCtx->mapSegmentName[0], G_IM_FMT_IA,
                                            gMapData->owMinimapWidth[mapIndex], gMapData->owMinimapHeight[mapIndex], 0,
-                                           G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK,
+                                           mirrorMode | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK,
                                            G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
 
                     s16 oWMiniMapX = OTRGetRectDimensionFromRightEdge(R_OW_MINIMAP_X + X_Margins_Minimap);
@@ -848,9 +874,16 @@ void Minimap_Draw(PlayState* play) {
                             oWMiniMapX = -9999;
                         }
                     }
+
+                    s32 sValue = 0;
+                    if (CVarGetInteger("gMirroredWorld", 0)) {
+                        // Flip the minimap on the x-axis (s-axis) by setting s to the textures mirror boundary
+                        sValue = gMapData->owMinimapWidth[mapIndex] << 5;
+                    }
+
                     gSPWideTextureRectangle(OVERLAY_DISP++, oWMiniMapX << 2, oWMiniMapY << 2,
                                            (oWMiniMapX + gMapData->owMinimapWidth[mapIndex]) << 2,
-                                           (oWMiniMapY + gMapData->owMinimapHeight[mapIndex]) << 2, G_TX_RENDERTILE, 0,
+                                           (oWMiniMapY + gMapData->owMinimapHeight[mapIndex]) << 2, G_TX_RENDERTILE, sValue,
                                             0, 1 << 10, 1 << 10);
 
                     gDPSetPrimColor(OVERLAY_DISP++, 0, 0, minimapColor.r, minimapColor.g, minimapColor.b, interfaceCtx->minimapAlpha);
@@ -860,8 +893,22 @@ void Minimap_Draw(PlayState* play) {
                         (LINK_AGE_IN_YEARS != YEARS_ADULT)) {
                         bool Map0 = gMapData->owEntranceIconPosY[sEntranceIconMapIndex] << 2 == 0;
                         s16 IconSize = 8;
-                        s16 PosX = gMapData->owEntranceIconPosX[sEntranceIconMapIndex] + (Map0 ? 0 : X_Margins_Minimap);
-                        s16 PosY = gMapData->owEntranceIconPosY[sEntranceIconMapIndex] + (Map0 ? 0 : Y_Margins_Minimap);
+
+                        s16 origX = gMapData->owEntranceIconPosX[sEntranceIconMapIndex];
+
+                        // Compute the distance of the center of the original texture location to the center of the map
+                        // Then duplicate that and right-align the texture (extra 2 pixels are due to the texture being a 6px left-aligned in a 8px tex)
+                        s16 distFromCenter = (R_OW_MINIMAP_X + (gMapData->owMinimapWidth[mapIndex] / 2)) - (origX + (IconSize / 2));
+                        s16 mirrorOffset = distFromCenter * 2 + (IconSize / 2) - 2;
+                        s16 newX = origX + (CVarGetInteger("gMirroredWorld", 0) ? mirrorOffset : 0);
+                        // The game authentically uses larger negative values for the entrance icon Y pos value. Normally only the first 12 bits
+                        // would be read when the final value is passed into `gSPTextureRectangle`, but our cosmetic hud placements requires using
+                        // `gSPWideTextureRectangle` which reads the first 24 bits instead. This caused the icon to be placed off screen.
+                        // To address this, we take the only the first 8 bits (which are later left-shifted by 2 to get our final 12 bits)
+                        // to fix the entrance icon position when used with `gSPWideTextureRectangle`
+                        s16 newY = gMapData->owEntranceIconPosY[sEntranceIconMapIndex] & 0xFF;
+                        s16 PosX = newX + (Map0 ? 0 : X_Margins_Minimap);
+                        s16 PosY = newY + (Map0 ? 0 : Y_Margins_Minimap);
                         //gFixDungeonMinimapIcon fix both Y position of visible icon and hide these non needed.
 
                         s16 TopLeftX = (Map0 ? OTRGetRectDimensionFromLeftEdge(PosX) : OTRGetRectDimensionFromRightEdge(PosX)) << 2;
@@ -869,8 +916,8 @@ void Minimap_Draw(PlayState* play) {
                         s16 TopLeftW = (Map0 ? OTRGetRectDimensionFromLeftEdge(PosX + IconSize) : OTRGetRectDimensionFromRightEdge(PosX + IconSize)) << 2;
                         s16 TopLeftH = (PosY + IconSize) << 2;
                         if (CVarGetInteger("gMinimapPosType", 0) != 0) {
-                            PosX = gMapData->owEntranceIconPosX[sEntranceIconMapIndex] + CVarGetInteger("gMinimapPosX", 0) + X_Margins_Minimap;
-                            PosY = gMapData->owEntranceIconPosY[sEntranceIconMapIndex] + CVarGetInteger("gMinimapPosY", 0) + Y_Margins_Minimap;
+                            PosX = newX + CVarGetInteger("gMinimapPosX", 0) + X_Margins_Minimap;
+                            PosY = newY + CVarGetInteger("gMinimapPosY", 0) + Y_Margins_Minimap;
                             if (CVarGetInteger("gMinimapPosType", 0) == 1) {//Anchor Left
                                 if (CVarGetInteger("gMinimapUseMargins", 0) != 0) {X_Margins_Minimap = Left_MM_Margin;};
                                 TopLeftX = OTRGetRectDimensionFromLeftEdge(PosX) << 2;
@@ -887,10 +934,10 @@ void Minimap_Draw(PlayState* play) {
                                 TopLeftW = -9999 + IconSize << 2;
                             }
                             if (!CVarGetInteger("gMinimapPosType", 0) != 4 && Map0 && !CVarGetInteger("gFixDungeonMinimapIcon", 0)) { //Force top left icon if fix not applied.
-                                TopLeftX = OTRGetRectDimensionFromLeftEdge(gMapData->owEntranceIconPosX[sEntranceIconMapIndex]) << 2;
-                                TopLeftY = gMapData->owEntranceIconPosY[sEntranceIconMapIndex] << 2;
-                                TopLeftW = OTRGetRectDimensionFromLeftEdge(gMapData->owEntranceIconPosX[sEntranceIconMapIndex] + IconSize) << 2;
-                                TopLeftH = (gMapData->owEntranceIconPosY[sEntranceIconMapIndex] + IconSize) << 2;
+                                TopLeftX = OTRGetRectDimensionFromLeftEdge(newX) << 2;
+                                TopLeftY = newY << 2;
+                                TopLeftW = OTRGetRectDimensionFromLeftEdge(newX + IconSize) << 2;
+                                TopLeftH = (newY + IconSize) << 2;
                             }
                         }
                         if (CVarGetInteger("gFixDungeonMinimapIcon", 0) != 0){
@@ -911,18 +958,19 @@ void Minimap_Draw(PlayState* play) {
                         }
                     }
 
-                    s16 entranceX = OTRGetRectDimensionFromRightEdge(270 + X_Margins_Minimap);
+                    s16 origX = CVarGetInteger("gMirroredWorld", 0) ? 256 : 270;
+                    s16 entranceX = OTRGetRectDimensionFromRightEdge(origX + X_Margins_Minimap);
                     s16 entranceY = 154 + Y_Margins_Minimap;
                     if (CVarGetInteger("gMinimapPosType", 0) != 0) {
                         entranceY = 154 + Y_Margins_Minimap + CVarGetInteger("gMinimapPosY", 0);
                         if (CVarGetInteger("gMinimapPosType", 0) == 1) {//Anchor Left
                             if (CVarGetInteger("gMinimapUseMargins", 0) != 0) {X_Margins_Minimap = Left_MM_Margin;};
-                            entranceX = OTRGetRectDimensionFromLeftEdge(270 + X_Margins_Minimap + CVarGetInteger("gMinimapPosX", 0));
+                            entranceX = OTRGetRectDimensionFromLeftEdge(origX + X_Margins_Minimap + CVarGetInteger("gMinimapPosX", 0));
                         } else if (CVarGetInteger("gMinimapPosType", 0) == 2) {//Anchor Right
                             if (CVarGetInteger("gMinimapUseMargins", 0) != 0) {X_Margins_Minimap = Right_MM_Margin;};
-                            entranceX = OTRGetRectDimensionFromRightEdge(270 + X_Margins_Minimap + CVarGetInteger("gMinimapPosX", 0));
+                            entranceX = OTRGetRectDimensionFromRightEdge(origX + X_Margins_Minimap + CVarGetInteger("gMinimapPosX", 0));
                         } else if (CVarGetInteger("gMinimapPosType", 0) == 3) {//Anchor None
-                            entranceX = 270 + X_Margins_Minimap + CVarGetInteger("gMinimapPosX", 0);
+                            entranceX = origX + X_Margins_Minimap + CVarGetInteger("gMinimapPosX", 0);
                         } else if (CVarGetInteger("gMinimapPosType", 0) == 4) {//Hidden
                             entranceX = -9999;
                         }
@@ -932,7 +980,7 @@ void Minimap_Draw(PlayState* play) {
                         gDPLoadTextureBlock(OVERLAY_DISP++, gMapDungeonEntranceIconTex, G_IM_FMT_RGBA, G_IM_SIZ_16b, 8,
                                             8, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK,
                                             G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
-                        gSPWideTextureRectangle(OVERLAY_DISP++, entranceX << 2, entranceY << 2, (entranceX + 32) << 2, (entranceY + 8) << 2,
+                        gSPWideTextureRectangle(OVERLAY_DISP++, entranceX << 2, entranceY << 2, (entranceX + 8) << 2, (entranceY + 8) << 2,
                                                 G_TX_RENDERTILE, 0, 0, 1 << 10, 1 << 10);
                     } else if ((play->sceneNum == SCENE_SPOT08) && CVarGetInteger("gAlwaysShowDungeonMinimapIcon", 0) != 0){
 
@@ -940,7 +988,7 @@ void Minimap_Draw(PlayState* play) {
                                             8, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK,
                                             G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
 
-                        gSPWideTextureRectangle(OVERLAY_DISP++, entranceX << 2, entranceY << 2, (entranceX + 32) << 2, (entranceY + 8) << 2,
+                        gSPWideTextureRectangle(OVERLAY_DISP++, entranceX << 2, entranceY << 2, (entranceX + 8) << 2, (entranceY + 8) << 2,
                                                 G_TX_RENDERTILE, 0, 0, 1 << 10, 1 << 10);
                     }
 

--- a/soh/src/code/z_map_mark.c
+++ b/soh/src/code/z_map_mark.c
@@ -132,8 +132,19 @@ void MapMark_DrawForDungeon(PlayState* play) {
         //Place each chest / boss room icon
         for (i = 0; i < mapMarkIconData->count; i++) {
             if ((mapMarkIconData->markType != MAP_MARK_CHEST) || !Flags_GetTreasure(play, markPoint->chestFlag)) {
+                markInfo = &sMapMarkInfoTable[mapMarkIconData->markType];
+                int height = markInfo->textureHeight * 1.0f; //Adjust Height with scale
+                int width = markInfo->textureWidth * 1.0f; //Adjust Width with scale
+                int height_factor = (1 << 10) * markInfo->textureHeight / height;
+                int width_factor = (1 << 10) * markInfo->textureWidth / width;
+
+                // The original mark point X originates from the left edge of the map
+                // For mirror mode, we compute the new mark point X by subtracting it from the right side of the
+                // dungeon map and the textures width
+                s16 markPointX = CVarGetInteger("gMirroredWorld", 0) ? 96 - markPoint->x - width : markPoint->x;
+
                 //Minimap chest / boss icon 
-                const s32 PosX_Minimap_ori = GREG(94) + OTRGetRectDimensionFromRightEdge(markPoint->x+X_Margins_Minimap_ic) + 204;
+                const s32 PosX_Minimap_ori = GREG(94) + OTRGetRectDimensionFromRightEdge(markPointX+X_Margins_Minimap_ic) + 204;
                 const s32 PosY_Minimap_ori = GREG(95) + markPoint->y + Y_Margins_Minimap_ic + 140;
                 if (CVarGetInteger("gMinimapPosType", 0) != 0) {
                     rectTop = (markPoint->y + Y_Margins_Minimap_ic + 140 + CVarGetInteger("gMinimapPosY", 0));
@@ -143,15 +154,15 @@ void MapMark_DrawForDungeon(PlayState* play) {
                             play->sceneNum == SCENE_BMORI1 || play->sceneNum == SCENE_HIDAN || play->sceneNum == SCENE_MIZUSIN || 
                             play->sceneNum == SCENE_JYASINZOU || play->sceneNum == SCENE_HAKADAN || play->sceneNum == SCENE_HAKADANCH || 
                             play->sceneNum == SCENE_ICE_DOUKUTO) {
-                            rectLeft = OTRGetRectDimensionFromLeftEdge(markPoint->x+CVarGetInteger("gMinimapPosX", 0)+204+X_Margins_Minimap_ic);
+                            rectLeft = OTRGetRectDimensionFromLeftEdge(markPointX+CVarGetInteger("gMinimapPosX", 0)+204+X_Margins_Minimap_ic);
                         } else {
-                            rectLeft = OTRGetRectDimensionFromLeftEdge(markPoint->x+CVarGetInteger("gMinimapPosX", 0)+204+X_Margins_Minimap_ic);
+                            rectLeft = OTRGetRectDimensionFromLeftEdge(markPointX+CVarGetInteger("gMinimapPosX", 0)+204+X_Margins_Minimap_ic);
                         }
                     } else if (CVarGetInteger("gMinimapPosType", 0) == 2) {//Anchor Right
                         if (CVarGetInteger("gMinimapUseMargins", 0) != 0) {X_Margins_Minimap_ic = Right_MC_Margin;};
-                        rectLeft = OTRGetRectDimensionFromRightEdge(markPoint->x+CVarGetInteger("gMinimapPosX", 0)+204+X_Margins_Minimap_ic);
+                        rectLeft = OTRGetRectDimensionFromRightEdge(markPointX+CVarGetInteger("gMinimapPosX", 0)+204+X_Margins_Minimap_ic);
                     } else if (CVarGetInteger("gMinimapPosType", 0) == 3) {//Anchor None
-                        rectLeft = markPoint->x+CVarGetInteger("gMinimapPosX", 0)+204+X_Margins_Minimap_ic;
+                        rectLeft = markPointX+CVarGetInteger("gMinimapPosX", 0)+204+X_Margins_Minimap_ic;
                     } else if (CVarGetInteger("gMinimapPosType", 0) == 4) {//Hidden
                         rectLeft = -9999;
                     }
@@ -159,13 +170,6 @@ void MapMark_DrawForDungeon(PlayState* play) {
                     rectLeft = PosX_Minimap_ori;
                     rectTop = PosY_Minimap_ori;
                 }
-
-                int height = 8 * 1.0f; //Adjust Height with scale
-                int width = 8 * 1.0f; //Adjust Width with scale
-                int height_factor = (1 << 10) * 8 / height;
-                int width_factor = (1 << 10) * 8 / width;
-
-                markInfo = &sMapMarkInfoTable[mapMarkIconData->markType];
 
                 gDPPipeSync(OVERLAY_DISP++);
 


### PR DESCRIPTION
This PR accomplishes mirroring the minimap for mirror world.

The following things are happening:
* The minimap texture is set to mirror on wrap, and then the texture drawing offsets the x-axis (s-axis) to start on the mirror boundary
* Compass arrows are mirrored by adding an additional mirror offset value that is computed by comparing the original offset value against the end and center of the minimap
* Overworld Dungeon entrance icons use a similar approach to add an additional mirror offset value
* Dungeon chest/boss icons also use a similar additional mirror offset value

Notably, dungeon minimaps are all strictly 96px wide, but are bottom right-aligned for rooms that are smaller. The mirroring approach means that in mirror mode, small rooms will have their minimap bottom left-aligned (within the 96px area). Trying to avoid that would probably me a math nightmare and not worth solving for.

Tested all maps and hud placement options.

Additionally I fixed the issue preventing dungeon entrance icons from display at all due to a authentic data issue being interpreted wrong by a custom Fast3D command.
I may consider PRing this fix upstream.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/728904222.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/728904223.zip)
  - [soh-linux-performance.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/728904224.zip)
  - [soh-mac.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/728904225.zip)
  - [soh-switch.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/728904226.zip)
<!--- section:artifacts:end -->