### PR TITLE
Implement mirrored Kaleido maps for Mirror World

### DIFF
--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
@@ -813,7 +813,8 @@ Gfx* KaleidoScope_QuadTextureIA4(Gfx* gfx, void* texture, s16 width, s16 height,
 }
 
 Gfx* KaleidoScope_QuadTextureIA8(Gfx* gfx, void* texture, s16 width, s16 height, u16 point) {
-    gDPLoadTextureBlock(gfx++, texture, G_IM_FMT_IA, G_IM_SIZ_8b, width, height, 0, G_TX_NOMIRROR | G_TX_WRAP,
+    u8 mirrorMode = CVarGetInteger("gMirroredWorld", 0) ? G_TX_MIRROR : G_TX_NOMIRROR;
+    gDPLoadTextureBlock(gfx++, texture, G_IM_FMT_IA, G_IM_SIZ_8b, width, height, 0, mirrorMode | G_TX_WRAP,
                         G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
     gSP1Quadrangle(gfx++, point, point + 2, point + 3, point + 1, 0);
 

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_lmap_mark.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_lmap_mark.c
@@ -131,8 +131,11 @@ void PauseMapMark_DrawForDungeon(PlayState* play) {
                                     markInfo->textureWidth, markInfo->textureHeight, 0, G_TX_NOMIRROR | G_TX_WRAP,
                                     G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
 
+                // Compute the offset to mirror icons over the map center (48) as an axis line
+                s16 mirrorOffset = CVarGetInteger("gMirroredWorld", 0) ? mirrorOffset = (48 - markPoint->x) * 2 + 1 : 0;
+
                 Matrix_Push();
-                Matrix_Translate(GREG(92) + markPoint->x, GREG(93) + markPoint->y, 0.0f, MTXMODE_APPLY);
+                Matrix_Translate(GREG(92) + markPoint->x + mirrorOffset, GREG(93) + markPoint->y, 0.0f, MTXMODE_APPLY);
                 Matrix_Scale(scale, scale, scale, MTXMODE_APPLY);
                 gSPMatrix(POLY_KAL_DISP++, MATRIX_NEWMTX(play->state.gfxCtx),
                           G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);


### PR DESCRIPTION
This PR implements the flipped maps and icons for both the dungeon and overworld maps 🚀 

For the dungeon maps, vertices are used to render the main map as two rectangle halves. To achieve flipping, I've hijacked the specific vertices for the rectangles and applied an offset to the U value (which controls the s-axis position of the texture) to point it to the mirror boundary. Because the two rectangles are separate textures, we also had to swap the vertices so the left half renders on the right side (flipped) for mirror mode. The chests and boss icons can be mirrored by applying an offset to the matrix translate so they are placed on the other side of the maps center axis line.

For the overworld map, again vertices are used to render the main map, the dots, the clouds, the blue highlight area, and the cursors. Since the overworld map as a whole is centered on the screen, I was able to use a matrix scale of -1 on the x-axis to flip the entire map and all the textures. Then I applied the mirror boundary U value (s-axis position) hijack on the specific vertices for the "current position" and current area name textures so they render left-to-right correctly. The last part was to make it so pressing left will move the cursor right and vice-versa, so that moving across the map is seamless. Reversing culling was needed as we are flipping the order of the vertices, but since we already flipped culling for the whole kaleido menu to "fix" it in mirror mode, we have to un-flip the culling specifically for the overworld map and then flip it back once we are done with the map.

Hijacking the vertices works here as the vertices are recreated on each draw frame, so toggling mirror mode on the fly doesn't have to "undo" any changes thankfully.

![image](https://github.com/garrettjoecox/OOT/assets/13861068/c45bb03a-9bfa-4961-8b72-cb2c34e4fe81)
![image](https://github.com/garrettjoecox/OOT/assets/13861068/bad38014-846d-4cd3-ac15-0b766fa94995)
![image](https://github.com/garrettjoecox/OOT/assets/13861068/fd39cd64-c758-4592-9689-c31dee6416f9)
![image](https://github.com/garrettjoecox/OOT/assets/13861068/7b062072-8963-4a96-bbe5-0780347db738)


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/730815051.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/730815052.zip)
  - [soh-linux-performance.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/730815053.zip)
  - [soh-mac.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/730815054.zip)
  - [soh-switch.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/730815055.zip)
  - [soh-windows.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/730815056.zip)
<!--- section:artifacts:end -->