### PR TITLE
Use invert culling command

### DIFF
--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -4024,7 +4024,7 @@ void Interface_DrawItemButtons(PlayState* play) {
                                    G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
 
             gDPPipeSync(OVERLAY_DISP++);
-            gSPSetGeometryMode(OVERLAY_DISP++, CVarGetInteger("gMirroredWorld", 0) ? G_CULL_FRONT : G_CULL_BACK);
+            gSPSetGeometryMode(OVERLAY_DISP++, G_CULL_BACK);
             gDPSetCombineLERP(OVERLAY_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0,
                             PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
             gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, interfaceCtx->startAlpha);
@@ -5369,8 +5369,7 @@ void Interface_Draw(PlayState* play) {
             Interface_DrawActionButton(play, PosX_BtnA, PosY_BtnA);
         }
         gDPPipeSync(OVERLAY_DISP++);
-        // Invert culling since we are not flipping z_parameter for mirror world
-        gSPSetGeometryMode(OVERLAY_DISP++, CVarGetInteger("gMirroredWorld", 0) ? G_CULL_FRONT : G_CULL_BACK);
+        gSPSetGeometryMode(OVERLAY_DISP++, G_CULL_BACK);
         gDPSetCombineLERP(OVERLAY_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0,
                           PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
         gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, interfaceCtx->aAlpha);

--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -1472,13 +1472,15 @@ void Play_Draw(PlayState* play) {
         func_800AA460(&play->view, play->view.fovy, play->view.zNear, play->lightCtx.fogFar);
         func_800AAA50(&play->view, 15);
 
+        // Flip the projections and invert culling for the OPA and XLU display buffers
+        // These manage the world and effects
         if (CVarGetInteger("gMirroredWorld", 0)) {
+            gSPSetExtraGeometryMode(POLY_OPA_DISP++, G_EX_INVERT_CULLING);
+            gSPSetExtraGeometryMode(POLY_XLU_DISP++, G_EX_INVERT_CULLING);
             gSPMatrix(POLY_OPA_DISP++, play->view.projectionFlippedPtr, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
             gSPMatrix(POLY_XLU_DISP++, play->view.projectionFlippedPtr, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
-            gSPMatrix(POLY_KAL_DISP++, play->view.projectionFlippedPtr, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
             gSPMatrix(POLY_OPA_DISP++, play->view.viewingPtr, G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
             gSPMatrix(POLY_XLU_DISP++, play->view.viewingPtr, G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
-            gSPMatrix(POLY_KAL_DISP++, play->view.viewingPtr, G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
         }
 
         // The billboard matrix temporarily stores the viewing matrix
@@ -1701,6 +1703,12 @@ void Play_Draw(PlayState* play) {
                     }
                 }
             }
+        }
+
+        // Reset the inverted culling
+        if (CVarGetInteger("gMirroredWorld", 0)) {
+            gSPClearExtraGeometryMode(POLY_OPA_DISP++, G_EX_INVERT_CULLING);
+            gSPClearExtraGeometryMode(POLY_XLU_DISP++, G_EX_INVERT_CULLING);
         }
     }
 

--- a/soh/src/code/z_rcp.c
+++ b/soh/src/code/z_rcp.c
@@ -1300,10 +1300,6 @@ void Gfx_SetupDL_42Kal(GraphicsContext* gfxCtx) {
     OPEN_DISPS(gfxCtx);
 
     gSPDisplayList(POLY_KAL_DISP++, sSetupDL[SETUPDL_42]);
-    if (CVarGetInteger("gMirroredWorld", 0)) {
-        gSPClearGeometryMode(POLY_KAL_DISP++, G_CULL_BACK);
-        gSPSetGeometryMode(POLY_KAL_DISP++, G_CULL_FRONT);
-    }
 
     CLOSE_DISPS(gfxCtx);
 }
@@ -1312,10 +1308,6 @@ void Gfx_SetupDL_42Overlay(GraphicsContext* gfxCtx) {
     OPEN_DISPS(gfxCtx);
 
     gSPDisplayList(OVERLAY_DISP++, sSetupDL[SETUPDL_42]);
-    if (CVarGetInteger("gMirroredWorld", 0)) {
-        gSPClearGeometryMode(OVERLAY_DISP++, G_CULL_BACK);
-        gSPSetGeometryMode(OVERLAY_DISP++, G_CULL_FRONT);
-    }
 
     CLOSE_DISPS(gfxCtx);
 }

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_map_PAL.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_map_PAL.c
@@ -537,11 +537,10 @@ void KaleidoScope_DrawWorldMap(PlayState* play, GraphicsContext* gfxCtx) {
         }
     }
 
-    // Use matrix scaling to flip the entire map for mirror world
+    // Use matrix scaling to flip the entire overworld map for mirror world
     if (mirroredWorld) {
-        // Undo the culling change back to "normal" since culling is reversed, but map is vertices are also flipped
-        gSPClearGeometryMode(POLY_KAL_DISP++, G_CULL_FRONT);
-        gSPSetGeometryMode(POLY_KAL_DISP++, G_CULL_BACK);
+        // Invert culling to counter act the matrix flip
+        gSPSetExtraGeometryMode(POLY_KAL_DISP++, G_EX_INVERT_CULLING);
         Matrix_Push();
         Matrix_Scale(-1.0f, 1.0f, 1.0f, MTXMODE_APPLY);
         gSPMatrix(POLY_KAL_DISP++, MATRIX_NEWMTX(gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
@@ -805,9 +804,8 @@ void KaleidoScope_DrawWorldMap(PlayState* play, GraphicsContext* gfxCtx) {
     gDPPipeSync(POLY_KAL_DISP++);
 
     if (mirroredWorld) {
-        // Reset culling to back for mirror mode
-        gSPClearGeometryMode(POLY_KAL_DISP++, G_CULL_BACK);
-        gSPSetGeometryMode(POLY_KAL_DISP++, G_CULL_FRONT);
+        // Revert the inversion
+        gSPClearExtraGeometryMode(POLY_KAL_DISP++, G_EX_INVERT_CULLING);
     }
 
     CLOSE_DISPS(gfxCtx);

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
@@ -3042,13 +3042,12 @@ void KaleidoScope_Draw(PlayState* play) {
 
     func_800AAA50(&play->view, 15);
 
+    // Flip the OPA and XLU projections again as the set view call above reset the original flips from z_play
     if (CVarGetInteger("gMirroredWorld", 0)) {
         gSPMatrix(POLY_OPA_DISP++, play->view.projectionFlippedPtr, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
         gSPMatrix(POLY_XLU_DISP++, play->view.projectionFlippedPtr, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
-        gSPMatrix(POLY_KAL_DISP++, play->view.projectionFlippedPtr, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
         gSPMatrix(POLY_OPA_DISP++, play->view.viewingPtr, G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
         gSPMatrix(POLY_XLU_DISP++, play->view.viewingPtr, G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
-        gSPMatrix(POLY_KAL_DISP++, play->view.viewingPtr, G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
     }
 
     CLOSE_DISPS(play->state.gfxCtx);


### PR DESCRIPTION
This leverages the new `gSPExtraGeometryMode` op code to set inverted culling at a F3D level. https://github.com/Kenix3/libultraship/pull/310

This new command allows us better control when culling should be inverted. We strictly only need to enable it for the OPA and XLU display buffers, as OVERLAY and KAL are not being flipped.

I also removed the KAL projection flipping as it didn't seem necessary anymore with the better culling logic.

The overworld map logic can now use the invert culling command to selectively only invert culling for the overworld map page.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/739552101.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/739552102.zip)
  - [soh-linux-performance.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/739552103.zip)
  - [soh-mac.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/739552104.zip)
  - [soh-switch.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/739552105.zip)
  - [soh-windows.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/739552106.zip)
<!--- section:artifacts:end -->