### PR TITLE
update bluewarp handling for entrance rando

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer_entrance.c
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance.c
@@ -445,34 +445,31 @@ void Entrance_SetWarpSongEntrance(void) {
 }
 
 void Entrance_OverrideBlueWarp(void) {
-    // Set nextEntranceIndex as a flag so that Grotto_CheckSpecialEntrance
-    // won't return index 0x7FFF, which can't work to override blue warps.
-    gPlayState->nextEntranceIndex = 0;
+    // Handles first time entering bluewarp (with item give)
+    switch (gSaveContext.entranceIndex) {
+        case 0x0457: // Gohma blue warp
+        case 0x047A: // KD blue warp
+        case 0x010E: // Barinade blue warp
+        case 0x0608: // Phantom Ganon blue warp
+        case 0x0564: // Volvagia blue warp
+        case 0x060C: // Morpha blue warp
+        case 0x0610: // Bongo-Bongo blue warp
+        case 0x0580: // Twinrova blue warp
+            gSaveContext.entranceIndex = Entrance_OverrideNextIndex(gSaveContext.entranceIndex);
+            return;
+    }
 
-    switch (gPlayState->sceneNum) {
-        case SCENE_YDAN_BOSS: // Ghoma boss room
-            gPlayState->nextEntranceIndex = Entrance_OverrideNextIndex(0x0457);
-            return;
-        case SCENE_DDAN_BOSS: // King Dodongo boss room
-            gPlayState->nextEntranceIndex = Entrance_OverrideNextIndex(0x047A);
-            return;
-        case SCENE_BDAN_BOSS: // Barinade boss room
-            gPlayState->nextEntranceIndex = Entrance_OverrideNextIndex(0x010E);
-            return;
-        case SCENE_MORIBOSSROOM: // Phantom Ganon boss room
-            gPlayState->nextEntranceIndex = Entrance_OverrideNextIndex(0x0608);
-            return;
-        case SCENE_FIRE_BS: // Volvagia boss room
-            gPlayState->nextEntranceIndex = Entrance_OverrideNextIndex(0x0564);
-            return;
-        case SCENE_MIZUSIN_BS: // Morpha boss room
-            gPlayState->nextEntranceIndex = Entrance_OverrideNextIndex(0x060C);
-            return;
-        case SCENE_JYASINBOSS: // Bongo-Bongo boss room
-            gPlayState->nextEntranceIndex = Entrance_OverrideNextIndex(0x0610);
-            return;
-        case SCENE_HAKADAN_BS: // Twinrova boss room
-            gPlayState->nextEntranceIndex = Entrance_OverrideNextIndex(0x0580);
+    // Handles second+ times entering bluewarp
+    switch (gPlayState->nextEntranceIndex) {
+        case 0x0457: // Gohma blue warp
+        case 0x047A: // KD blue warp
+        case 0x010E: // Barinade blue warp
+        case 0x0608: // Phantom Ganon blue warp
+        case 0x0564: // Volvagia blue warp
+        case 0x060C: // Morpha blue warp
+        case 0x0610: // Bongo-Bongo blue warp
+        case 0x0580: // Twinrova blue warp
+            gPlayState->nextEntranceIndex = Entrance_OverrideNextIndex(gPlayState->nextEntranceIndex);
             return;
     }
 }

--- a/soh/src/code/z_demo.c
+++ b/soh/src/code/z_demo.c
@@ -2150,41 +2150,55 @@ void Cutscene_HandleConditionalTriggers(PlayState* play) {
     osSyncPrintf("\ngame_info.mode=[%d] restart_flag", ((void)0, gSaveContext.respawnFlag));
 
     if (gSaveContext.n64ddFlag) {
+        uint8_t isBlueWarp = 0;
         // Deku Tree Blue warp
         if (gSaveContext.entranceIndex == 0xEE && gSaveContext.cutsceneIndex == 0xFFF1) {
             gSaveContext.entranceIndex = 0x457;
             gSaveContext.cutsceneIndex = 0;
+            isBlueWarp = 1;
         // Dodongo's Cavern Blue warp
         } else if (gSaveContext.entranceIndex == 0x13D && gSaveContext.cutsceneIndex == 0xFFF1) {
             gSaveContext.entranceIndex = 0x47A;
             gSaveContext.cutsceneIndex = 0;
+            isBlueWarp = 1;
         // Jabu Jabu's Blue warp
         } else if (gSaveContext.entranceIndex == 0x10E && gSaveContext.cutsceneIndex == 0xFFF0) {
             gSaveContext.entranceIndex = 0x10E;
             gSaveContext.cutsceneIndex = 0;
+            isBlueWarp = 1;
         // Forest Temple Blue warp
         } else if (gSaveContext.entranceIndex == 0x6B && gSaveContext.cutsceneIndex == 0x0 && gSaveContext.chamberCutsceneNum == CHAMBER_CS_FOREST) {
             gSaveContext.entranceIndex = 0x608;
             gSaveContext.cutsceneIndex = 0;
+            isBlueWarp = 1;
         // Fire Temple Blue warp
         } else if (gSaveContext.entranceIndex == 0xDB && gSaveContext.cutsceneIndex == 0xFFF3) {
             gSaveContext.entranceIndex = 0x564;
             gSaveContext.cutsceneIndex = 0;
+            isBlueWarp = 1;
         // Water Temple Blue warp
         } else if (gSaveContext.entranceIndex == 0x6B && gSaveContext.cutsceneIndex == 0x0 && gSaveContext.chamberCutsceneNum == CHAMBER_CS_WATER) {
             gSaveContext.entranceIndex = 0x60C;
             gSaveContext.cutsceneIndex = 0;
+            isBlueWarp = 1;
         // Spirit Temple Blue warp
         } else if (gSaveContext.entranceIndex == 0x6B && gSaveContext.cutsceneIndex == 0x0 && gSaveContext.chamberCutsceneNum == CHAMBER_CS_SPIRIT) {
             gSaveContext.entranceIndex = 0x610;
             gSaveContext.cutsceneIndex = 0;
+            isBlueWarp = 1;
         // Shadow Temple Blue warp
         } else if (gSaveContext.entranceIndex == 0x6B && gSaveContext.cutsceneIndex == 0x0 && gSaveContext.chamberCutsceneNum == CHAMBER_CS_SHADOW) {
             gSaveContext.entranceIndex = 0x580;
             gSaveContext.cutsceneIndex = 0;
+            isBlueWarp = 1;
         // Zelda escaping with impa cutscene
         } else if (gSaveContext.entranceIndex == 0xCD && gSaveContext.cutsceneIndex == 0xFFF1) {
             gSaveContext.cutsceneIndex = 0;
+        }
+
+        if (isBlueWarp && (Randomizer_GetSettingValue(RSK_SHUFFLE_DUNGEON_ENTRANCES) != RO_DUNGEON_ENTRANCE_SHUFFLE_OFF ||
+            Randomizer_GetSettingValue(RSK_SHUFFLE_BOSS_ENTRANCES) != RO_BOSS_ROOM_ENTRANCE_SHUFFLE_OFF)) {
+            Entrance_OverrideBlueWarp();
         }
     }
 


### PR DESCRIPTION
Updates bluewarp handling in entrance rando, both for first time use, and second+ time use.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/761024351.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/761024352.zip)
  - [soh-linux-performance.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/761024353.zip)
  - [soh-mac.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/761024354.zip)
  - [soh-switch.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/761024355.zip)
  - [soh-wiiu.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/761024356.zip)
  - [soh-windows.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/761024357.zip)
<!--- section:artifacts:end -->