### PR TITLE
Oops All Skeletons

### DIFF
--- a/soh/soh/Enhancements/controls/GameControlEditor.cpp
+++ b/soh/soh/Enhancements/controls/GameControlEditor.cpp
@@ -233,6 +233,9 @@ namespace GameControlEditor {
         window->BeginGroupPanelPublic("Aiming/First-Person Camera", ImGui::GetContentRegionAvail());
         UIWidgets::PaddedEnhancementCheckbox("Right Stick Aiming", "gRightStickAiming");
         DrawHelpIcon("Allows for aiming with the right stick in:\n-First-Person/C-Up view\n-Weapon Aiming");
+        if (CVarGetInteger("gRightStickAiming", 0)) {
+            UIWidgets::PaddedEnhancementCheckbox("Allow moving while in first person mode", "gMoveWhileFirstPerson");
+        }
         UIWidgets::PaddedEnhancementCheckbox("Invert Aiming X Axis", "gInvertAimingXAxis");
         DrawHelpIcon("Inverts the Camera X Axis in:\n-First-Person/C-Up view\n-Weapon Aiming");
         UIWidgets::PaddedEnhancementCheckbox("Invert Aiming Y Axis", "gInvertAimingYAxis", true, true, false, "", UIWidgets::CheckboxGraphics::Cross, true);
@@ -245,7 +248,8 @@ namespace GameControlEditor {
         DrawHelpIcon("Prevents the C-Up view from auto-centering, allowing for Gyro Aiming");
         if (UIWidgets::PaddedEnhancementCheckbox("Enable Custom Aiming/First-Person sensitivity", "gEnableFirstPersonSensitivity", true, false)) {
             if (!CVarGetInteger("gEnableFirstPersonSensitivity", 0)) {
-                CVarClear("gFirstPersonCameraSensitivity");
+                CVarClear("gFirstPersonCameraSensitivityX");
+                CVarClear("gFirstPersonCameraSensitivityY");
             }
         }
         if (CVarGetInteger("gEnableFirstPersonSensitivity", 0)) {

--- a/soh/soh/Enhancements/enemyrandomizer.cpp
+++ b/soh/soh/Enhancements/enemyrandomizer.cpp
@@ -12,55 +12,55 @@ extern "C" {
 extern "C" uint32_t ResourceMgr_IsSceneMasterQuest(s16 sceneNum);
 
 static EnemyEntry randomizedEnemySpawnTable[RANDOMIZED_ENEMY_SPAWN_TABLE_SIZE] = {
-    { ACTOR_EN_FIREFLY, 2 },    // Regular Keese
-    { ACTOR_EN_FIREFLY, 1 },    // Fire Keese
-    { ACTOR_EN_FIREFLY, 4 },    // Ice Keese
-    { ACTOR_EN_TEST, 2 },       // Stalfos
-    { ACTOR_EN_TITE, -1 },      // Tektite (red)
-    { ACTOR_EN_TITE, -2 },      // Tektite (blue)
-    { ACTOR_EN_WALLMAS, 1 },    // Wallmaster
-    { ACTOR_EN_DODONGO, -1 },   // Dodongo
-    { ACTOR_EN_PEEHAT, -1 },    // Flying Peahat (big grounded, doesn't spawn larva)
-    { ACTOR_EN_PEEHAT, 1 },     // Flying Peahat Larva
-    { ACTOR_EN_ZF, -1 },        // Lizalfos
-    { ACTOR_EN_ZF, -2 },        // Dinolfos
-    { ACTOR_EN_GOMA, 7 },       // Gohma larva (non-gohma rooms)
-    { ACTOR_EN_BUBBLE, 0 },     // Shabom (bubble)
-    { ACTOR_EN_DODOJR, 0 },     // Baby Dodongo
-    { ACTOR_EN_TORCH2, 0 },     // Dark Link
-    { ACTOR_EN_BILI, 0 },       // Biri (jellyfish)
-    { ACTOR_EN_TP, -1 },        // Electric Tailparasan
-    { ACTOR_EN_ST, 0 },         // Skulltula (normal)
-    { ACTOR_EN_ST, 1 },         // Skulltula (big)
-    { ACTOR_EN_ST, 2 },         // Skulltula (invisible)
-    { ACTOR_EN_BW, 0 },         // Torch Slug
-    { ACTOR_EN_EIYER, 10 },     // Stinger (land) (One in formation, sink under floor and do not activate)
-    { ACTOR_EN_MB, 0 },         // Moblins (Club)
-    { ACTOR_EN_DEKUBABA, 0 },   // Deku Baba (small)
-    { ACTOR_EN_DEKUBABA, 1 },   // Deku Baba (large)
-    { ACTOR_EN_AM, -1 },        // Armos (enemy variant)
-    { ACTOR_EN_DEKUNUTS, 768 }, // Mad Scrub (triple attack) (projectiles don't work)
-    { ACTOR_EN_VALI, -1 },      // Bari (big jellyfish)
-    { ACTOR_EN_BB, -1 },        // Bubble (flying skull enemy) (blue)
-    { ACTOR_EN_YUKABYUN, 0 },   // Flying Floor Tile
-    { ACTOR_EN_VM, 1280 },      // Beamos
-    { ACTOR_EN_FLOORMAS, 0 },   // Floormaster
-    { ACTOR_EN_RD, 1 },         // Redead (standing)
-    { ACTOR_EN_RD, 32766 },     // Gibdo (standing)
-    { ACTOR_EN_SB, 0 },         // Shell Blade
-    { ACTOR_EN_KAREBABA, 0 },   // Withered Deku Baba
-    { ACTOR_EN_RR, 0 },         // Like-Like
-    { ACTOR_EN_NY, 0 },         // Spike (rolling enemy)
-    { ACTOR_EN_IK, 2 },         // Iron Knuckle (black, standing)
-    { ACTOR_EN_IK, 3 },         // Iron Knuckle (white, standing)
-    { ACTOR_EN_TUBO_TRAP, 0 },  // Flying pot
-    { ACTOR_EN_FZ, 0 },         // Freezard
-    { ACTOR_EN_CLEAR_TAG, 1 },  // Arwing
-    { ACTOR_EN_WF, 0 },         // Wolfos (normal)
-    { ACTOR_EN_WF, 1 },         // Wolfos (white)
+    // { ACTOR_EN_FIREFLY, 2 },    // Regular Keese
+    // { ACTOR_EN_FIREFLY, 1 },    // Fire Keese
+    // { ACTOR_EN_FIREFLY, 4 },    // Ice Keese
+    // { ACTOR_EN_TEST, 2 },       // Stalfos
+    // { ACTOR_EN_TITE, -1 },      // Tektite (red)
+    // { ACTOR_EN_TITE, -2 },      // Tektite (blue)
+    // { ACTOR_EN_WALLMAS, 1 },    // Wallmaster
+    // { ACTOR_EN_DODONGO, -1 },   // Dodongo
+    // { ACTOR_EN_PEEHAT, -1 },    // Flying Peahat (big grounded, doesn't spawn larva)
+    // { ACTOR_EN_PEEHAT, 1 },     // Flying Peahat Larva
+    // { ACTOR_EN_ZF, -1 },        // Lizalfos
+    // { ACTOR_EN_ZF, -2 },        // Dinolfos
+    // { ACTOR_EN_GOMA, 7 },       // Gohma larva (non-gohma rooms)
+    // { ACTOR_EN_BUBBLE, 0 },     // Shabom (bubble)
+    // { ACTOR_EN_DODOJR, 0 },     // Baby Dodongo
+    // { ACTOR_EN_TORCH2, 0 },     // Dark Link
+    // { ACTOR_EN_BILI, 0 },       // Biri (jellyfish)
+    // { ACTOR_EN_TP, -1 },        // Electric Tailparasan
+    // { ACTOR_EN_ST, 0 },         // Skulltula (normal)
+    // { ACTOR_EN_ST, 1 },         // Skulltula (big)
+    // { ACTOR_EN_ST, 2 },         // Skulltula (invisible)
+    // { ACTOR_EN_BW, 0 },         // Torch Slug
+    // { ACTOR_EN_EIYER, 10 },     // Stinger (land) (One in formation, sink under floor and do not activate)
+    // { ACTOR_EN_MB, 0 },         // Moblins (Club)
+    // { ACTOR_EN_DEKUBABA, 0 },   // Deku Baba (small)
+    // { ACTOR_EN_DEKUBABA, 1 },   // Deku Baba (large)
+    // { ACTOR_EN_AM, -1 },        // Armos (enemy variant)
+    // { ACTOR_EN_DEKUNUTS, 768 }, // Mad Scrub (triple attack) (projectiles don't work)
+    // { ACTOR_EN_VALI, -1 },      // Bari (big jellyfish)
+    // { ACTOR_EN_BB, -1 },        // Bubble (flying skull enemy) (blue)
+    // { ACTOR_EN_YUKABYUN, 0 },   // Flying Floor Tile
+    // { ACTOR_EN_VM, 1280 },      // Beamos
+    // { ACTOR_EN_FLOORMAS, 0 },   // Floormaster
+    // { ACTOR_EN_RD, 1 },         // Redead (standing)
+    // { ACTOR_EN_RD, 32766 },     // Gibdo (standing)
+    // { ACTOR_EN_SB, 0 },         // Shell Blade
+    // { ACTOR_EN_KAREBABA, 0 },   // Withered Deku Baba
+    // { ACTOR_EN_RR, 0 },         // Like-Like
+    // { ACTOR_EN_NY, 0 },         // Spike (rolling enemy)
+    // { ACTOR_EN_IK, 2 },         // Iron Knuckle (black, standing)
+    // { ACTOR_EN_IK, 3 },         // Iron Knuckle (white, standing)
+    // { ACTOR_EN_TUBO_TRAP, 0 },  // Flying pot
+    // { ACTOR_EN_FZ, 0 },         // Freezard
+    // { ACTOR_EN_CLEAR_TAG, 1 },  // Arwing
+    // { ACTOR_EN_WF, 0 },         // Wolfos (normal)
+    // { ACTOR_EN_WF, 1 },         // Wolfos (white)
     { ACTOR_EN_SKB, 1 },        // Stalchild (small)
-    { ACTOR_EN_SKB, 20 },       // Stalchild (big)
-    { ACTOR_EN_CROW, 0 }        // Guay
+    // { ACTOR_EN_SKB, 20 },       // Stalchild (big)
+    // { ACTOR_EN_CROW, 0 }        // Guay
 
     // Doesn't work {ACTOR_EN_POH, 0}, // Poe (Seems to rely on other objects?)
     // Doesn't work {ACTOR_EN_POH, 2}, // Poe (composer Sharp) (Seems to rely on other objects?)

--- a/soh/soh/Enhancements/enemyrandomizer.h
+++ b/soh/soh/Enhancements/enemyrandomizer.h
@@ -7,7 +7,7 @@ typedef struct EnemyEntry {
     int16_t params;
 } EnemyEntry;
 
-#define RANDOMIZED_ENEMY_SPAWN_TABLE_SIZE 49
+#define RANDOMIZED_ENEMY_SPAWN_TABLE_SIZE 1
 
 bool IsEnemyFoundToRandomize(int16_t sceneNum, int8_t roomNum, int16_t actorId, int16_t params, float posX);
 bool IsEnemyAllowedToSpawn(int16_t sceneNum, int8_t roomNum, EnemyEntry enemy);

--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -1059,4 +1059,14 @@ void InitMods() {
     RegisterAltTrapTypes();
     RegisterRandomizerSheikSpawn();
     NameTag_RegisterHooks();
+
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnPlayerUpdate>([]() {
+        if (gPlayState == NULL) return;
+        gPlayState->envCtx.adjFogColor[0] = 0;
+        gPlayState->envCtx.adjFogColor[1] = 0;
+        gPlayState->envCtx.adjFogColor[2] = 0;
+        if (gPlayState->envCtx.adjFogNear > -84) {
+            gPlayState->envCtx.adjFogNear--;
+        }
+    });
 }

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -790,6 +790,13 @@ extern "C" void InitOTR() {
         CVarClear("gLetItSnow");
     }
 
+    CVarSetInteger("gInfiniteAmmo", 1);
+    CVarSetInteger("gHyperEnemies", 1);
+    CVarSetInteger("gDamageMul", 1);
+    CVarSetInteger("gRandomizedEnemies", 1);
+    CVarSetInteger("gShadowTag", 1);
+    CVarSetInteger("gBonkDamageMul", 7);
+
     srand(now);
 #ifdef ENABLE_CROWD_CONTROL
     CrowdControl::Instance = new CrowdControl();

--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -754,6 +754,30 @@ void Play_Init(GameState* thisx) {
     }
     #endif
 
+    if (
+        (!IS_DAY && (
+            play->sceneNum == SCENE_KOKIRI_FOREST ||
+            play->sceneNum == SCENE_KAKARIKO_VILLAGE ||
+            play->sceneNum == SCENE_GRAVEYARD ||
+            play->sceneNum == SCENE_GERUDOS_FORTRESS ||
+            play->sceneNum == SCENE_HAUNTED_WASTELAND ||
+            play->sceneNum == SCENE_LOST_WOODS ||
+            play->sceneNum == SCENE_SACRED_FOREST_MEADOW ||
+            play->sceneNum == SCENE_LON_LON_RANCH ||
+            play->sceneNum == SCENE_ZORAS_FOUNTAIN ||
+            play->sceneNum == SCENE_DEATH_MOUNTAIN_CRATER
+        )) ||
+        (play->sceneNum == SCENE_HYRULE_FIELD && LINK_IS_ADULT) ||
+        play->sceneNum == SCENE_DEATH_MOUNTAIN_TRAIL ||
+        play->sceneNum == SCENE_GERUDO_VALLEY ||
+        play->sceneNum == SCENE_ZORAS_RIVER ||
+        play->sceneNum == SCENE_LAKE_HYLIA
+    ) {
+        Actor_Spawn(&play->actorCtx, play, ACTOR_EN_ENCOUNT1, GET_PLAYER(play)->actor.world.pos.x,
+                        GET_PLAYER(play)->actor.world.pos.y + Player_GetHeight(GET_PLAYER(play)) + 5.0f,
+                        GET_PLAYER(play)->actor.world.pos.z, 0, 0, 0, 4260, false);
+    }
+
     if (CVarGetInteger("gIvanCoopModeEnabled", 0)) {
         Actor_Spawn(&play->actorCtx, play, gEnPartnerId, GET_PLAYER(play)->actor.world.pos.x,
                     GET_PLAYER(play)->actor.world.pos.y + Player_GetHeight(GET_PLAYER(play)) + 5.0f,

--- a/soh/src/overlays/actors/ovl_En_Encount1/z_en_encount1.c
+++ b/soh/src/overlays/actors/ovl_En_Encount1/z_en_encount1.c
@@ -224,13 +224,7 @@ void EnEncount1_SpawnStalchildOrWolfos(EnEncount1* this, PlayState* play) {
     s32 bgId;
     f32 floorY;
 
-    if (play->sceneNum != SCENE_HYRULE_FIELD) {
-        if ((fabsf(player->actor.world.pos.y - this->actor.world.pos.y) > 100.0f) ||
-            (this->actor.xzDistToPlayer > this->spawnRange)) {
-            this->outOfRangeTimer++;
-            return;
-        }
-    } else if (IS_DAY || (Player_GetMask(play) == PLAYER_MASK_BUNNY)) {
+    if (IS_DAY) {
         this->killCount = 0;
         return;
     }
@@ -247,7 +241,7 @@ void EnEncount1_SpawnStalchildOrWolfos(EnEncount1* this, PlayState* play) {
             (CVarGetInteger("gRandomizedEnemies", 0) && enemyCount < 15)) {
         while ((this->curNumSpawn < this->maxCurSpawns && this->totalNumSpawn < this->maxTotalSpawns) || 
                 (CVarGetInteger("gRandomizedEnemies", 0) && enemyCount < 15)) {
-            if (play->sceneNum == SCENE_HYRULE_FIELD) {
+            // if (play->sceneNum == SCENE_HYRULE_FIELD) {
                 if ((player->unk_89E == 0) || (player->actor.floorBgId != BGCHECK_SCENE) ||
                     !(player->actor.bgCheckFlags & 1) || (player->stateFlags1 & 0x08000000)) {
 
@@ -282,7 +276,7 @@ void EnEncount1_SpawnStalchildOrWolfos(EnEncount1* this, PlayState* play) {
                     break;
                 }
                 spawnPos.y = floorY;
-            }
+            // }
             if (this->spawnType == SPAWNER_WOLFOS) {
                 spawnId = ACTOR_EN_WF;
                 spawnParams = (0xFF << 8) | 0x00;
@@ -305,9 +299,9 @@ void EnEncount1_SpawnStalchildOrWolfos(EnEncount1* this, PlayState* play) {
                 if (this->curNumSpawn >= this->maxCurSpawns) {
                     this->fieldSpawnTimer = 100;
                 }
-                if (play->sceneNum != SCENE_HYRULE_FIELD) {
-                    this->totalNumSpawn++;
-                }
+                // if (play->sceneNum != SCENE_HYRULE_FIELD) {
+                    // this->totalNumSpawn++;
+                // }
             } else {
                 // "Cannot spawn!"
                 osSyncPrintf(VT_FGCOL(GREEN) "☆☆☆☆☆ 発生できません！ ☆☆☆☆☆\n" VT_RST);

--- a/soh/src/overlays/actors/ovl_En_Skb/z_en_skb.c
+++ b/soh/src/overlays/actors/ovl_En_Skb/z_en_skb.c
@@ -152,7 +152,7 @@ void EnSkb_Init(Actor* thisx, PlayState* play) {
     ActorShape_Init(&this->actor.shape, 0.0f, ActorShadow_DrawCircle, 0.0f);
     this->actor.focus.pos = this->actor.world.pos;
     this->actor.colChkInfo.mass = 0xFE;
-    this->actor.colChkInfo.health = 2;
+    this->actor.colChkInfo.health = 4;
     this->actor.shape.yOffset = -8000.0f;
     SkelAnime_Init(play, &this->skelAnime, &gStalchildSkel, &gStalchildUncurlingAnim, this->jointTable,
                    this->morphTable, 20);

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -11384,58 +11384,101 @@ void Player_Destroy(Actor* thisx, PlayState* play) {
 
 //first person manipulate player actor
 s16 func_8084ABD8(PlayState* play, Player* this, s32 arg2, s16 arg3) {
-    s32 temp1;
-    s16 temp2;
-    s16 temp3;
-    bool gInvertAimingXAxis = (CVarGetInteger("gInvertAimingXAxis", 0) && !CVarGetInteger("gMirroredWorld", 0)) || (!CVarGetInteger("gInvertAimingXAxis", 0) && CVarGetInteger("gMirroredWorld", 0));
+    s32 temp1 = 0;
+    s16 temp2 = 0;
+    s16 temp3 = 0;
+    s8 invertXAxisMulti = ((CVarGetInteger("gInvertAimingXAxis", 0) && !CVarGetInteger("gMirroredWorld", 0)) || (!CVarGetInteger("gInvertAimingXAxis", 0) && CVarGetInteger("gMirroredWorld", 0))) ? -1 : 1;
+    s8 invertYAxisMulti = CVarGetInteger("gInvertAimingYAxis", 1) ? 1 : -1;
+    f32 xAxisMulti = CVarGetFloat("gFirstPersonCameraSensitivityX", 1.0f);
+    f32 yAxisMulti = CVarGetFloat("gFirstPersonCameraSensitivityY", 1.0f);
 
-    if (!func_8002DD78(this) && !func_808334B4(this) && (arg2 == 0) && !CVarGetInteger("gDisableAutoCenterViewFirstPerson", 0)) {
-        temp2 = sControlInput->rel.stick_y * 240.0f * (CVarGetInteger("gInvertAimingYAxis", 1) ? 1 : -1); // Sensitivity not applied here because higher than default sensitivies will allow the camera to escape the autocentering, and glitch out massively
-        Math_SmoothStepToS(&this->actor.focus.rot.x, temp2, 14, 4000, 30);
+    if (!func_8002DD78(this) && !func_808334B4(this) && (arg2 == 0)) { // First person without weapon
+        // Y Axis
+        if (!CVarGetInteger("gMoveWhileFirstPerson", 0)) {
+            temp2 += sControlInput->rel.stick_y * 240.0f * invertYAxisMulti * yAxisMulti;
+        }
+        if (CVarGetInteger("gRightStickAiming", 0) && fabsf(sControlInput->cur.right_stick_y) > 15.0f) {
+            temp2 += sControlInput->cur.right_stick_y * 240.0f * invertYAxisMulti * yAxisMulti;
+        }
+        if (fabsf(sControlInput->cur.gyro_x) > 0.01f) {
+            temp2 += (-sControlInput->cur.gyro_x) * 750.0f;
+        }
+        if (CVarGetInteger("gDisableAutoCenterViewFirstPerson", 0)) {
+            this->actor.focus.rot.x += temp2 * 0.1f;
+            this->actor.focus.rot.x = CLAMP(this->actor.focus.rot.x, -14000, 14000);
+        } else {
+            Math_SmoothStepToS(&this->actor.focus.rot.x, temp2, 14, 4000, 30);
+        }
 
-        temp2 = sControlInput->rel.stick_x * -16.0f * (gInvertAimingXAxis ? -1 : 1) * (CVarGetFloat("gFirstPersonCameraSensitivityX", 1.0f));
+        // X Axis
+        temp2 = 0;
+        if (!CVarGetInteger("gMoveWhileFirstPerson", 0)) {
+            temp2 += sControlInput->rel.stick_x * -16.0f * invertXAxisMulti * xAxisMulti;
+        }
+        if (CVarGetInteger("gRightStickAiming", 0) && fabsf(sControlInput->cur.right_stick_x) > 15.0f) {
+            temp2 += sControlInput->cur.right_stick_x * -16.0f * invertXAxisMulti * xAxisMulti;
+        }
+        if (fabsf(sControlInput->cur.gyro_y) > 0.01f) {
+            temp2 += (sControlInput->cur.gyro_y) * 750.0f * invertXAxisMulti;
+        }
         temp2 = CLAMP(temp2, -3000, 3000);
         this->actor.focus.rot.y += temp2;
-    } else {
+    } else { // First person with weapon
+        // Y Axis
         temp1 = (this->stateFlags1 & PLAYER_STATE1_ON_HORSE) ? 3500 : 14000;
-        temp3 = ((sControlInput->rel.stick_y >= 0) ? 1 : -1) *
-                (s32)((1.0f - Math_CosS(sControlInput->rel.stick_y * 200)) * 1500.0f *
-                        (CVarGetInteger("gInvertAimingYAxis", 1) ? 1 : -1)) * (CVarGetFloat("gFirstPersonCameraSensitivityY", 1.0f));
-        this->actor.focus.rot.x += temp3;
-
+        
+        if (!CVarGetInteger("gMoveWhileFirstPerson", 0)) {
+            temp3 += ((sControlInput->rel.stick_y >= 0) ? 1 : -1) *
+                    (s32)((1.0f - Math_CosS(sControlInput->rel.stick_y * 200)) * 1500.0f) * invertYAxisMulti * yAxisMulti;
+        }
+        if (CVarGetInteger("gRightStickAiming", 0) && fabsf(sControlInput->cur.right_stick_y) > 15.0f) {
+            temp3 += ((sControlInput->cur.right_stick_y >= 0) ? 1 : -1) *
+                    (s32)((1.0f - Math_CosS(sControlInput->cur.right_stick_y * 200)) * 1500.0f) * invertYAxisMulti * yAxisMulti;
+        }
         if (fabsf(sControlInput->cur.gyro_x) > 0.01f) {
-            this->actor.focus.rot.x -= (sControlInput->cur.gyro_x) * 750.0f;
+            temp3 += (-sControlInput->cur.gyro_x) * 750.0f;
         }
-
-        if (fabsf(sControlInput->cur.right_stick_y) > 15.0f && CVarGetInteger("gRightStickAiming", 0) != 0) {
-            this->actor.focus.rot.x -=
-                (sControlInput->cur.right_stick_y) * 10.0f * (CVarGetInteger("gInvertAimingYAxis", 1) ? -1 : 1) * (CVarGetFloat("gFirstPersonCameraSensitivityY", 1.0f));
-        }
-
+        this->actor.focus.rot.x += temp3;
         this->actor.focus.rot.x = CLAMP(this->actor.focus.rot.x, -temp1, temp1);
 
+        // X Axis
         temp1 = 19114;
         temp2 = this->actor.focus.rot.y - this->actor.shape.rot.y;
-        temp3 = ((sControlInput->rel.stick_x >= 0) ? 1 : -1) *
-                (s32)((1.0f - Math_CosS(sControlInput->rel.stick_x * 200)) * -1500.0f *
-                        (gInvertAimingXAxis ? -1 : 1)) * (CVarGetFloat("gFirstPersonCameraSensitivityX", 1.0f));
-        temp2 += temp3;
-
-        this->actor.focus.rot.y = CLAMP(temp2, -temp1, temp1) + this->actor.shape.rot.y;
-
+        temp3 = 0;
+        if (!CVarGetInteger("gMoveWhileFirstPerson", 0)) {
+            temp3 = ((sControlInput->rel.stick_x >= 0) ? 1 : -1) *
+                    (s32)((1.0f - Math_CosS(sControlInput->rel.stick_x * 200)) * -1500.0f) * invertXAxisMulti * xAxisMulti;
+        }
+        if (CVarGetInteger("gRightStickAiming", 0) && fabsf(sControlInput->cur.right_stick_x) > 15.0f) {
+            temp3 += ((sControlInput->cur.right_stick_x >= 0) ? 1 : -1) *
+                    (s32)((1.0f - Math_CosS(sControlInput->cur.right_stick_x * 200)) * -1500.0f) * invertXAxisMulti * xAxisMulti;
+        }
         if (fabsf(sControlInput->cur.gyro_y) > 0.01f) {
-            this->actor.focus.rot.y += (sControlInput->cur.gyro_y) * 750.0f * (CVarGetInteger("gMirroredWorld", 0) ? -1 : 1);
+            temp3 += (sControlInput->cur.gyro_y) * 750.0f * invertXAxisMulti;
         }
+        temp2 += temp3;
+        this->actor.focus.rot.y = CLAMP(temp2, -temp1, temp1) + this->actor.shape.rot.y;
+    }
 
-        if (fabsf(sControlInput->cur.right_stick_x) > 15.0f && CVarGetInteger("gRightStickAiming", 0) != 0) {
-            this->actor.focus.rot.y +=
-                (sControlInput->cur.right_stick_x) * 10.0f * (gInvertAimingXAxis ? 1 : -1) * (CVarGetFloat("gFirstPersonCameraSensitivityX", 1.0f));
-        }
+    if (CVarGetInteger("gMoveWhileFirstPerson", 0)) {
+        f32 movementSpeed = 1.0f;
+        if (CVarGetInteger("gMMBunnyHood", BUNNY_HOOD_VANILLA) != BUNNY_HOOD_VANILLA && this->currentMask == PLAYER_MASK_BUNNY) {
+            movementSpeed = 1.5f;
+        } 
+        f32 relX = (sControlInput->cur.stick_x / 10.0f * -invertXAxisMulti) * movementSpeed;
+        f32 relY = (sControlInput->cur.stick_y / 10.0f) * movementSpeed;
+
+        // Determine what left and right mean based on camera angle
+        f32 relX2 = relX * Math_CosS(this->actor.focus.rot.y) + relY * Math_SinS(this->actor.focus.rot.y);
+        f32 relY2 = relY * Math_CosS(this->actor.focus.rot.y) - relX * Math_SinS(this->actor.focus.rot.y);
+
+        // Apply the movement
+        this->actor.world.pos.x += relX2;
+        this->actor.world.pos.z += relY2;
     }
 
     this->unk_6AE |= 2;
-    return func_80836AB8(this, (play->shootingGalleryStatus != 0) || func_8002DD78(this) || func_808334B4(this)) -
-           arg3;
+    return func_80836AB8(this, (play->shootingGalleryStatus != 0) || func_8002DD78(this) || func_808334B4(this)) - arg3;
 }
 
 void func_8084AEEC(Player* this, f32* arg1, f32 arg2, s16 arg3) {


### PR DESCRIPTION
Changes
- Allow moving while in first person Enhancement (Set this up in your controller options, requires "right stick aiming" to be on)
- Infinite ammo (for encouraged use of first person enhancement)
- All enemies are Stalchildren
- Stalchildren spawning in overworld
- Stalchildren double health, double damage, twice as fast
- Foggy Hyrule
- Shadow Tag
- NO BONKS ALLOWED

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1014089852.zip)
  - [soh-linux-performance.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1014089854.zip)
  - [soh-mac.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1014089856.zip)
  - [soh-switch.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1014089858.zip)
  - [soh-wiiu.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1014089860.zip)
  - [soh-windows.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1014089861.zip)
<!--- section:artifacts:end -->


https://github.com/garrettjoecox/OOT/assets/7316699/dfe884b5-53cb-4993-bc4f-d8bb3f8f97b6