### PR TITLE
Rename func_8002F434 to Actor_OfferGetItem to match ZRET/oot name

### DIFF
--- a/soh/include/functions.h
+++ b/soh/include/functions.h
@@ -457,11 +457,11 @@ u32 Actor_TextboxIsClosing(Actor* actor, PlayState* play);
 s8 func_8002F368(PlayState* play);
 void Actor_GetScreenPos(PlayState* play, Actor* actor, s16* x, s16* y);
 u32 Actor_HasParent(Actor* actor, PlayState* play);
-// TODO: Rename the follwing 3 functions using whatever scheme we use when we rename func_8002F434 and func_8002F554.
+// TODO: Rename the follwing 3 functions using whatever scheme we use when we rename Actor_OfferGetItem and func_8002F554.
 s32 GiveItemEntryWithoutActor(PlayState* play, GetItemEntry getItemEntry);
 s32 GiveItemEntryFromActor(Actor* actor, PlayState* play, GetItemEntry getItemEntry, f32 xzRange, f32 yRange);
 s32 GiveItemEntryFromActorWithFixedRange(Actor* actor, PlayState* play, GetItemEntry getItemEntry);
-s32 func_8002F434(Actor* actor, PlayState* play, s32 getItemId, f32 xzRange, f32 yRange);
+s32 Actor_OfferGetItem(Actor* actor, PlayState* play, s32 getItemId, f32 xzRange, f32 yRange);
 void func_8002F554(Actor* actor, PlayState* play, s32 getItemId);
 void func_8002F580(Actor* actor, PlayState* play);
 u32 Actor_HasNoParent(Actor* actor, PlayState* play);

--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -2080,7 +2080,7 @@ s32 GiveItemEntryFromActorWithFixedRange(Actor* actor, PlayState* play, GetItemE
 
 // TODO: Rename to GiveItemIdFromActor or similar
 // If you're doing something for randomizer, you're probably looking for GiveItemEntryFromActor
-s32 func_8002F434(Actor* actor, PlayState* play, s32 getItemId, f32 xzRange, f32 yRange) {
+s32 Actor_OfferGetItem(Actor* actor, PlayState* play, s32 getItemId, f32 xzRange, f32 yRange) {
     Player* player = GET_PLAYER(play);
 
     if (!(player->stateFlags1 & 0x3C7080) && Player_GetExplosiveHeld(player) < 0) {
@@ -2107,7 +2107,7 @@ s32 func_8002F434(Actor* actor, PlayState* play, s32 getItemId, f32 xzRange, f32
 // TODO: Rename to GiveItemIdFromActorWithFixedRange or similar
 // If you're doing something for randomizer, you're probably looking for GiveItemEntryFromActorWithFixedRange
 void func_8002F554(Actor* actor, PlayState* play, s32 getItemId) {
-    func_8002F434(actor, play, getItemId, 50.0f, 10.0f);
+    Actor_OfferGetItem(actor, play, getItemId, 50.0f, 10.0f);
 }
 
 void func_8002F580(Actor* actor, PlayState* play) {

--- a/soh/src/code/z_en_item00.c
+++ b/soh/src/code/z_en_item00.c
@@ -732,7 +732,7 @@ void func_8001E5C8(EnItem00* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
     if (this->getItemId != GI_NONE) {
         if (!Actor_HasParent(&this->actor, play)) {
-            func_8002F434(&this->actor, play, this->getItemId, 50.0f, 80.0f);
+            Actor_OfferGetItem(&this->actor, play, this->getItemId, 50.0f, 80.0f);
             this->unk_15A++;
         } else {
             this->getItemId = GI_NONE;

--- a/soh/src/overlays/actors/ovl_En_Ani/z_en_ani.c
+++ b/soh/src/overlays/actors/ovl_En_Ani/z_en_ani.c
@@ -129,7 +129,7 @@ void func_809B0558(EnAni* this, PlayState* play) {
         Flags_SetItemGetInf(ITEMGETINF_15);
     } else {
         if (!IS_RANDO) {
-            func_8002F434(&this->actor, play, GI_HEART_PIECE, 10000.0f, 200.0f);
+            Actor_OfferGetItem(&this->actor, play, GI_HEART_PIECE, 10000.0f, 200.0f);
         } else {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_KAK_MAN_ON_ROOF, GI_HEART_PIECE);
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, 10000.0f, 200.0f);
@@ -143,7 +143,7 @@ void func_809B05F0(EnAni* this, PlayState* play) {
     }
 
     if (!IS_RANDO) {
-        func_8002F434(&this->actor, play, GI_HEART_PIECE, 10000.0f, 200.0f);
+        Actor_OfferGetItem(&this->actor, play, GI_HEART_PIECE, 10000.0f, 200.0f);
     } else {
         GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_KAK_MAN_ON_ROOF, GI_HEART_PIECE);
         GiveItemEntryFromActor(&this->actor, play, getItemEntry, 10000.0f, 200.0f);

--- a/soh/src/overlays/actors/ovl_En_Bom_Bowl_Pit/z_en_bom_bowl_pit.c
+++ b/soh/src/overlays/actors/ovl_En_Bom_Bowl_Pit/z_en_bom_bowl_pit.c
@@ -203,7 +203,7 @@ void EnBomBowlPit_GivePrize(EnBomBowlPit* this, PlayState* play) {
     player->stateFlags1 &= ~0x20000000;
     this->actor.parent = NULL;
     if (!IS_RANDO || this->getItemEntry.getItemId == GI_NONE) {
-        func_8002F434(&this->actor, play, this->getItemId, 2000.0f, 1000.0f);
+        Actor_OfferGetItem(&this->actor, play, this->getItemId, 2000.0f, 1000.0f);
     } else {
         GiveItemEntryFromActor(&this->actor, play, this->getItemEntry, 2000.0f, 1000.0f);
     }
@@ -216,7 +216,7 @@ void EnBomBowlPit_WaitTillPrizeGiven(EnBomBowlPit* this, PlayState* play) {
         this->actionFunc = EnBomBowlPit_Reset;
     } else {
          if (!IS_RANDO || this->getItemEntry.getItemId == GI_NONE) {
-            func_8002F434(&this->actor, play, this->getItemId, 2000.0f, 1000.0f);
+            Actor_OfferGetItem(&this->actor, play, this->getItemId, 2000.0f, 1000.0f);
         } else {
             GiveItemEntryFromActor(&this->actor, play, this->getItemEntry, 2000.0f, 1000.0f);
         }

--- a/soh/src/overlays/actors/ovl_En_Cow/z_en_cow.c
+++ b/soh/src/overlays/actors/ovl_En_Cow/z_en_cow.c
@@ -214,7 +214,7 @@ void func_809DF778(EnCow* this, PlayState* play) {
         this->actor.parent = NULL;
         this->actionFunc = func_809DF730;
     } else {
-        func_8002F434(&this->actor, play, GI_MILK, 10000.0f, 100.0f);
+        Actor_OfferGetItem(&this->actor, play, GI_MILK, 10000.0f, 100.0f);
     }
 }
 
@@ -223,7 +223,7 @@ void func_809DF7D8(EnCow* this, PlayState* play) {
         this->actor.flags &= ~ACTOR_FLAG_WILL_TALK;
         Message_CloseTextbox(play);
         this->actionFunc = func_809DF778;
-        func_8002F434(&this->actor, play, GI_MILK, 10000.0f, 100.0f);
+        Actor_OfferGetItem(&this->actor, play, GI_MILK, 10000.0f, 100.0f);
     }
 }
 

--- a/soh/src/overlays/actors/ovl_En_Diving_Game/z_en_diving_game.c
+++ b/soh/src/overlays/actors/ovl_En_Diving_Game/z_en_diving_game.c
@@ -456,7 +456,7 @@ void func_809EEA00(EnDivingGame* this, PlayState* play) {
         Message_CloseTextbox(play);
         this->actor.parent = NULL;
         if (!IS_RANDO) {
-            func_8002F434(&this->actor, play, GI_SCALE_SILVER, 90.0f, 10.0f);
+            Actor_OfferGetItem(&this->actor, play, GI_SCALE_SILVER, 90.0f, 10.0f);
         } else {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_ZD_DIVING_MINIGAME, GI_SCALE_SILVER);
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, 90.0f, 10.0f);
@@ -471,7 +471,7 @@ void func_809EEA90(EnDivingGame* this, PlayState* play) {
         this->actionFunc = func_809EEAF8;
     } else {
         if (!IS_RANDO) {
-            func_8002F434(&this->actor, play, GI_SCALE_SILVER, 90.0f, 10.0f);
+            Actor_OfferGetItem(&this->actor, play, GI_SCALE_SILVER, 90.0f, 10.0f);
         } else {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_ZD_DIVING_MINIGAME, GI_SCALE_SILVER);
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, 90.0f, 10.0f);

--- a/soh/src/overlays/actors/ovl_En_Dns/z_en_dns.c
+++ b/soh/src/overlays/actors/ovl_En_Dns/z_en_dns.c
@@ -391,7 +391,7 @@ void func_809EFDD0(EnDns* this, PlayState* play) {
     GetItemEntry itemEntry = ItemTable_Retrieve(pendingGetItemId);
     gSaveContext.pendingSale = itemEntry.itemId;
     gSaveContext.pendingSaleMod = itemEntry.modIndex;
-    func_8002F434(&this->actor, play, pendingGetItemId, 130.0f, 100.0f);
+    Actor_OfferGetItem(&this->actor, play, pendingGetItemId, 130.0f, 100.0f);
 }
 
 void func_809EFEE8(EnDns* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Dnt_Jiji/z_en_dnt_jiji.c
+++ b/soh/src/overlays/actors/ovl_En_Dnt_Jiji/z_en_dnt_jiji.c
@@ -262,7 +262,7 @@ void EnDntJiji_Talk(EnDntJiji* this, PlayState* play) {
         Message_CloseTextbox(play);
         func_8002DF54(play, NULL, 7);
         this->actor.parent = NULL;
-        func_8002F434(&this->actor, play, this->getItemId, 400.0f, 200.0f);
+        Actor_OfferGetItem(&this->actor, play, this->getItemId, 400.0f, 200.0f);
         this->actionFunc = EnDntJiji_SetupGivePrize;
     }
 }
@@ -272,7 +272,7 @@ void EnDntJiji_SetupGivePrize(EnDntJiji* this, PlayState* play) {
     if (Actor_HasParent(&this->actor, play)) {
         this->actionFunc = EnDntJiji_GivePrize;
     } else {
-        func_8002F434(&this->actor, play, this->getItemId, 400.0f, 200.0f);
+        Actor_OfferGetItem(&this->actor, play, this->getItemId, 400.0f, 200.0f);
     }
 }
 

--- a/soh/src/overlays/actors/ovl_En_Ds/z_en_ds.c
+++ b/soh/src/overlays/actors/ovl_En_Ds/z_en_ds.c
@@ -95,7 +95,7 @@ void EnDs_GiveOddPotion(EnDs* this, PlayState* play) {
         this->actionFunc = EnDs_DisplayOddPotionText;
         gSaveContext.timer2State = 0;
     } else {
-        func_8002F434(&this->actor, play, GI_ODD_POTION, 10000.0f, 50.0f);
+        Actor_OfferGetItem(&this->actor, play, GI_ODD_POTION, 10000.0f, 50.0f);
     }
 }
 
@@ -105,7 +105,7 @@ void EnDs_TalkAfterBrewOddPotion(EnDs* this, PlayState* play) {
         this->actionFunc = EnDs_GiveOddPotion;
         u32 itemId = GI_ODD_POTION;
         if (GameInteractor_Should(GI_VB_TRADE_ODD_MUSHROOM, true, this)) {
-            func_8002F434(&this->actor, play, itemId, 10000.0f, 50.0f);
+            Actor_OfferGetItem(&this->actor, play, itemId, 10000.0f, 50.0f);
         }
     }
 }
@@ -178,7 +178,7 @@ void EnDs_GiveBluePotion(EnDs* this, PlayState* play) {
         this->actor.parent = NULL;
         this->actionFunc = EnDs_Talk;
     } else {
-        func_8002F434(&this->actor, play, GI_POTION_BLUE, 10000.0f, 50.0f);
+        Actor_OfferGetItem(&this->actor, play, GI_POTION_BLUE, 10000.0f, 50.0f);
     }
 }
 
@@ -200,7 +200,7 @@ void EnDs_OfferBluePotion(EnDs* this, PlayState* play) {
 
                         if (GameInteractor_Should(GI_VB_GIVE_ITEM_FROM_GRANNYS_SHOP, true, this)) {
                             GetItemEntry itemEntry = ItemTable_Retrieve(GI_POTION_BLUE);
-                            func_8002F434(&this->actor, play, GI_POTION_BLUE, 10000.0f, 50.0f);
+                            Actor_OfferGetItem(&this->actor, play, GI_POTION_BLUE, 10000.0f, 50.0f);
                             gSaveContext.pendingSale = itemEntry.itemId;
                             gSaveContext.pendingSaleMod = itemEntry.modIndex;
                         }

--- a/soh/src/overlays/actors/ovl_En_Du/z_en_du.c
+++ b/soh/src/overlays/actors/ovl_En_Du/z_en_du.c
@@ -582,7 +582,7 @@ void func_809FEC70(EnDu* this, PlayState* play) {
     } else {
         f32 xzRange = this->actor.xzDistToPlayer + 1.0f;
 
-        func_8002F434(&this->actor, play, GI_BRACELET, xzRange, fabsf(this->actor.yDistToPlayer) + 1.0f);
+        Actor_OfferGetItem(&this->actor, play, GI_BRACELET, xzRange, fabsf(this->actor.yDistToPlayer) + 1.0f);
     }
 }
 

--- a/soh/src/overlays/actors/ovl_En_Elf/z_en_elf.c
+++ b/soh/src/overlays/actors/ovl_En_Elf/z_en_elf.c
@@ -677,7 +677,7 @@ void func_80A0329C(EnElf* this, PlayState* play) {
 
         if (!(this->fairyFlags & FAIRY_FLAG_BIG)) {
             // GI_MAX in this case allows the player to catch the actor in a bottle
-            func_8002F434(&this->actor, play, GI_MAX, 80.0f, 60.0f);
+            Actor_OfferGetItem(&this->actor, play, GI_MAX, 80.0f, 60.0f);
         }
     }
 }

--- a/soh/src/overlays/actors/ovl_En_Ex_Item/z_en_ex_item.c
+++ b/soh/src/overlays/actors/ovl_En_Ex_Item/z_en_ex_item.c
@@ -415,7 +415,7 @@ void EnExItem_TargetPrizeApproach(EnExItem* this, PlayState* play) {
         }
 
         if (!IS_RANDO || getItemEntry.getItemId == GI_NONE) {
-            func_8002F434(&this->actor, play, getItemId, 2000.0f, 1000.0f);
+            Actor_OfferGetItem(&this->actor, play, getItemId, 2000.0f, 1000.0f);
         } else {
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, 2000.0f, 1000.0f);
         }
@@ -429,7 +429,7 @@ void EnExItem_TargetPrizeGive(EnExItem* this, PlayState* play) {
     } else {
         if (!IS_RANDO) {
             s32 getItemId = (CUR_UPG_VALUE(UPG_BULLET_BAG) == 2) ? GI_BULLET_BAG_50 : GI_BULLET_BAG_40;
-            func_8002F434(&this->actor, play, getItemId, 2000.0f, 1000.0f);
+            Actor_OfferGetItem(&this->actor, play, getItemId, 2000.0f, 1000.0f);
         } else {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_LW_TARGET_IN_WOODS, GI_BULLET_BAG_50);
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, 2000.0f, 1000.0f);

--- a/soh/src/overlays/actors/ovl_En_Fish/z_en_fish.c
+++ b/soh/src/overlays/actors/ovl_En_Fish/z_en_fish.c
@@ -716,7 +716,7 @@ void EnFish_OrdinaryUpdate(EnFish* this, PlayState* play) {
             EnFish_BeginRespawn(this);
         } else if (EnFish_InBottleRange(this, play)) {
             // GI_MAX in this case allows the player to catch the actor in a bottle
-            func_8002F434(&this->actor, play, GI_MAX, 80.0f, 20.0f);
+            Actor_OfferGetItem(&this->actor, play, GI_MAX, 80.0f, 20.0f);
         }
     }
 }

--- a/soh/src/overlays/actors/ovl_En_Fr/z_en_fr.c
+++ b/soh/src/overlays/actors/ovl_En_Fr/z_en_fr.c
@@ -1020,7 +1020,7 @@ void EnFr_Deactivate(EnFr* this, PlayState* play) {
     } else {
         this->actionFunc = EnFr_GiveReward;
         if (GameInteractor_Should(GI_VB_GIVE_ITEM_FROM_FROGS, true, this)) {
-            func_8002F434(&this->actor, play, this->reward, 30.0f, 100.0f);
+            Actor_OfferGetItem(&this->actor, play, this->reward, 30.0f, 100.0f);
         }
     }
 }
@@ -1030,7 +1030,7 @@ void EnFr_GiveReward(EnFr* this, PlayState* play) {
         this->actor.parent = NULL;
         this->actionFunc = EnFr_SetIdle;
     } else {
-        func_8002F434(&this->actor, play, this->reward, 30.0f, 100.0f);
+        Actor_OfferGetItem(&this->actor, play, this->reward, 30.0f, 100.0f);
     }
 }
 

--- a/soh/src/overlays/actors/ovl_En_Gb/z_en_gb.c
+++ b/soh/src/overlays/actors/ovl_En_Gb/z_en_gb.c
@@ -360,7 +360,7 @@ void func_80A2FA50(EnGb* this, PlayState* play) {
 void func_80A2FB40(EnGb* this, PlayState* play) {
     if (Message_GetState(&play->msgCtx) == TEXT_STATE_DONE && Message_ShouldAdvance(play)) {
         if (!IS_RANDO) {
-            func_8002F434(&this->dyna.actor, play, GI_BOTTLE, 100.0f, 10.0f);
+            Actor_OfferGetItem(&this->dyna.actor, play, GI_BOTTLE, 100.0f, 10.0f);
         } else {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_MARKET_10_BIG_POES, GI_BOTTLE);
             GiveItemEntryFromActor(&this->dyna.actor, play, getItemEntry, 100.0f, 10.0f);
@@ -375,7 +375,7 @@ void func_80A2FBB0(EnGb* this, PlayState* play) {
         this->actionFunc = func_80A2FC0C;
     } else {
         if (!IS_RANDO) {
-            func_8002F434(&this->dyna.actor, play, GI_BOTTLE, 100.0f, 10.0f);
+            Actor_OfferGetItem(&this->dyna.actor, play, GI_BOTTLE, 100.0f, 10.0f);
         } else {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_MARKET_10_BIG_POES, GI_BOTTLE);
             GiveItemEntryFromActor(&this->dyna.actor, play, getItemEntry, 100.0f, 10.0f);

--- a/soh/src/overlays/actors/ovl_En_Ge1/z_en_ge1.c
+++ b/soh/src/overlays/actors/ovl_En_Ge1/z_en_ge1.c
@@ -573,7 +573,7 @@ void EnGe1_WaitTillItemGiven_Archery(EnGe1* this, PlayState* play) {
         }
 
         if (!IS_RANDO || getItemEntry.getItemId == GI_NONE) {
-            func_8002F434(&this->actor, play, getItemId, 10000.0f, 50.0f);
+            Actor_OfferGetItem(&this->actor, play, getItemId, 10000.0f, 50.0f);
         } else {
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, 10000.0f, 50.0f);
         }
@@ -614,7 +614,7 @@ void EnGe1_BeginGiveItem_Archery(EnGe1* this, PlayState* play) {
     }
 
     if (!IS_RANDO || getItemEntry.getItemId == GI_NONE) {
-        func_8002F434(&this->actor, play, getItemId, 10000.0f, 50.0f);
+        Actor_OfferGetItem(&this->actor, play, getItemId, 10000.0f, 50.0f);
     } else {
         GiveItemEntryFromActor(&this->actor, play, getItemEntry, 10000.0f, 50.0f);
     }

--- a/soh/src/overlays/actors/ovl_En_Ge2/z_en_ge2.c
+++ b/soh/src/overlays/actors/ovl_En_Ge2/z_en_ge2.c
@@ -472,7 +472,7 @@ void EnGe2_WaitTillCardGiven(EnGe2* this, PlayState* play) {
         this->actionFunc = EnGe2_SetActionAfterTalk;
     } else {
         if (!IS_RANDO) {
-            func_8002F434(&this->actor, play, GI_GERUDO_CARD, 10000.0f, 50.0f);
+            Actor_OfferGetItem(&this->actor, play, GI_GERUDO_CARD, 10000.0f, 50.0f);
         } else {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_GF_GERUDO_MEMBERSHIP_CARD, GI_GERUDO_CARD);
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, 10000.0f, 50.0f);
@@ -486,7 +486,7 @@ void EnGe2_GiveCard(EnGe2* this, PlayState* play) {
         this->actor.flags &= ~ACTOR_FLAG_WILL_TALK;
         this->actionFunc = EnGe2_WaitTillCardGiven;
          if (!IS_RANDO) {
-            func_8002F434(&this->actor, play, GI_GERUDO_CARD, 10000.0f, 50.0f);
+            Actor_OfferGetItem(&this->actor, play, GI_GERUDO_CARD, 10000.0f, 50.0f);
         } else {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_GF_GERUDO_MEMBERSHIP_CARD, GI_GERUDO_CARD);
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, 10000.0f, 50.0f);

--- a/soh/src/overlays/actors/ovl_En_Ge3/z_en_ge3.c
+++ b/soh/src/overlays/actors/ovl_En_Ge3/z_en_ge3.c
@@ -145,7 +145,7 @@ void EnGe3_WaitTillCardGiven(EnGe3* this, PlayState* play) {
         this->actionFunc = EnGe3_Wait;
     } else {
         if (!IS_RANDO) {
-            func_8002F434(&this->actor, play, GI_GERUDO_CARD, 10000.0f, 50.0f);
+            Actor_OfferGetItem(&this->actor, play, GI_GERUDO_CARD, 10000.0f, 50.0f);
         } else {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_GF_GERUDO_MEMBERSHIP_CARD, GI_GERUDO_CARD);
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, 10000.0f, 50.0f);
@@ -159,7 +159,7 @@ void EnGe3_GiveCard(EnGe3* this, PlayState* play) {
         this->actor.flags &= ~ACTOR_FLAG_WILL_TALK;
         this->actionFunc = EnGe3_WaitTillCardGiven;
         if (!IS_RANDO) {
-            func_8002F434(&this->actor, play, GI_GERUDO_CARD, 10000.0f, 50.0f);
+            Actor_OfferGetItem(&this->actor, play, GI_GERUDO_CARD, 10000.0f, 50.0f);
         } else {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_GF_GERUDO_MEMBERSHIP_CARD, GI_GERUDO_CARD);
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, 10000.0f, 50.0f);

--- a/soh/src/overlays/actors/ovl_En_Gm/z_en_gm.c
+++ b/soh/src/overlays/actors/ovl_En_Gm/z_en_gm.c
@@ -250,7 +250,7 @@ void EnGm_ProcessChoiceIndex(EnGm* this, PlayState* play) {
                     this->actionFunc = func_80A3DD7C;
                 } else {
                     if (GameInteractor_Should(GI_VB_GIVE_ITEM_FROM_MEDIGORON, true, this)) {
-                        func_8002F434(&this->actor, play, GI_SWORD_KNIFE, 415.0f, 10.0f);
+                        Actor_OfferGetItem(&this->actor, play, GI_SWORD_KNIFE, 415.0f, 10.0f);
                     }
 
                     this->actionFunc = func_80A3DF00;
@@ -270,7 +270,7 @@ void func_80A3DF00(EnGm* this, PlayState* play) {
         this->actor.parent = NULL;
         this->actionFunc = func_80A3DF60;
     } else {
-        func_8002F434(&this->actor, play, GI_SWORD_KNIFE, 415.0f, 10.0f);
+        Actor_OfferGetItem(&this->actor, play, GI_SWORD_KNIFE, 415.0f, 10.0f);
     }
 }
 

--- a/soh/src/overlays/actors/ovl_En_Go/z_en_go.c
+++ b/soh/src/overlays/actors/ovl_En_Go/z_en_go.c
@@ -229,7 +229,7 @@ s16 EnGo_UpdateTalkState(PlayState* play, Actor* thisx) {
                     talkState = NPC_TALK_STATE_IDLE;
                     break;
                 case 0x3036:
-                    func_8002F434(thisx, play, GI_TUNIC_GORON, xzRange, yRange);
+                    Actor_OfferGetItem(thisx, play, GI_TUNIC_GORON, xzRange, yRange);
                     Flags_SetInfTable(INFTABLE_10D); // EnGo exclusive flag
                     talkState = NPC_TALK_STATE_ACTION;
                     break;
@@ -976,7 +976,7 @@ void EnGo_GetItem(EnGo* this, PlayState* play) {
 
         yDist = fabsf(this->actor.yDistToPlayer) + 1.0f;
         xzDist = this->actor.xzDistToPlayer + 1.0f;
-        func_8002F434(&this->actor, play, getItemId, xzDist, yDist);
+        Actor_OfferGetItem(&this->actor, play, getItemId, xzDist, yDist);
     }
 }
 

--- a/soh/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/soh/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -284,7 +284,7 @@ s32 EnGo2_SpawnDust(EnGo2* this, u8 initialTimer, f32 scale, f32 scaleStep, s32 
 
 void EnGo2_GetItem(EnGo2* this, PlayState* play, s32 getItemId) {
     this->getItemId = getItemId;
-    func_8002F434(&this->actor, play, getItemId, this->actor.xzDistToPlayer + 1.0f,
+    Actor_OfferGetItem(&this->actor, play, getItemId, this->actor.xzDistToPlayer + 1.0f,
                   fabsf(this->actor.yDistToPlayer) + 1.0f);
 }
 
@@ -1832,7 +1832,7 @@ void EnGo2_SetupGetItem(EnGo2* this, PlayState* play) {
         this->actor.parent = NULL;
         this->actionFunc = EnGo2_SetGetItem;
     } else {
-        func_8002F434(&this->actor, play, this->getItemId, this->actor.xzDistToPlayer + 1.0f, fabsf(this->actor.yDistToPlayer) + 1.0f);
+        Actor_OfferGetItem(&this->actor, play, this->getItemId, this->actor.xzDistToPlayer + 1.0f, fabsf(this->actor.yDistToPlayer) + 1.0f);
     }
 }
 

--- a/soh/src/overlays/actors/ovl_En_Hs/z_en_hs.c
+++ b/soh/src/overlays/actors/ovl_En_Hs/z_en_hs.c
@@ -162,7 +162,7 @@ void func_80A6E740(EnHs* this, PlayState* play) {
         Flags_SetRandomizerInf(RAND_INF_ADULT_TRADES_LW_TRADE_COJIRO);
         func_80A6E3A0(this, func_80A6E630);
     } else {
-        func_8002F434(&this->actor, play, GI_ODD_MUSHROOM, 10000.0f, 50.0f);
+        Actor_OfferGetItem(&this->actor, play, GI_ODD_MUSHROOM, 10000.0f, 50.0f);
     }
 
     this->unk_2A8 |= 1;
@@ -174,7 +174,7 @@ void func_80A6E7BC(EnHs* this, PlayState* play) {
             case 0:
                 func_80A6E3A0(this, func_80A6E740);
                 if (GameInteractor_Should(GI_VB_TRADE_COJIRO, true, this)) {
-                    func_8002F434(&this->actor, play, GI_ODD_MUSHROOM, 10000.0f, 50.0f);
+                    Actor_OfferGetItem(&this->actor, play, GI_ODD_MUSHROOM, 10000.0f, 50.0f);
                 }
                 break;
             case 1:

--- a/soh/src/overlays/actors/ovl_En_Hy/z_en_hy.c
+++ b/soh/src/overlays/actors/ovl_En_Hy/z_en_hy.c
@@ -411,7 +411,7 @@ s32 EnHy_IsOsAnimeObjectLoaded(EnHy* this, PlayState* play) {
 
 void func_80A6F7CC(EnHy* this, PlayState* play, s32 getItemId) {
     this->unkGetItemId = getItemId;
-    func_8002F434(&this->actor, play, getItemId, this->actor.xzDistToPlayer + 1.0f,
+    Actor_OfferGetItem(&this->actor, play, getItemId, this->actor.xzDistToPlayer + 1.0f,
                   fabsf(this->actor.yDistToPlayer) + 1.0f);
 }
 
@@ -1069,7 +1069,7 @@ void func_80A714C4(EnHy* this, PlayState* play) {
         this->actionFunc = func_80A71530;
     } else {
         if (!IS_RANDO || this->getItemEntry.getItemId == GI_NONE) {
-            func_8002F434(&this->actor, play, this->unkGetItemId, this->actor.xzDistToPlayer + 1.0f, fabsf(this->actor.yDistToPlayer) + 1.0f);
+            Actor_OfferGetItem(&this->actor, play, this->unkGetItemId, this->actor.xzDistToPlayer + 1.0f, fabsf(this->actor.yDistToPlayer) + 1.0f);
         } else {
             GiveItemEntryFromActor(&this->actor, play, this->getItemEntry, this->actor.xzDistToPlayer + 1.0f, fabsf(this->actor.yDistToPlayer) + 1.0f);
         }

--- a/soh/src/overlays/actors/ovl_En_Ice_Hono/z_en_ice_hono.c
+++ b/soh/src/overlays/actors/ovl_En_Ice_Hono/z_en_ice_hono.c
@@ -216,7 +216,7 @@ void EnIceHono_CapturableFlame(EnIceHono* this, PlayState* play) {
         this->actor.parent = NULL;
     } else if (EnIceHono_InBottleRange(this, play)) {
         // GI_MAX in this case allows the player to catch the actor in a bottle
-        func_8002F434(&this->actor, play, GI_MAX, 60.0f, 100.0f);
+        Actor_OfferGetItem(&this->actor, play, GI_MAX, 60.0f, 100.0f);
     }
 
     if (this->actor.xzDistToPlayer < 200.0f) {

--- a/soh/src/overlays/actors/ovl_En_Insect/z_en_insect.c
+++ b/soh/src/overlays/actors/ovl_En_Insect/z_en_insect.c
@@ -786,7 +786,7 @@ void EnInsect_Update(Actor* thisx, PlayState* play) {
 
             if (!(this->unk_314 & 8) && D_80A7DEB4 < 4 && EnInsect_InBottleRange(this, play) &&
                 // GI_MAX in this case allows the player to catch the actor in a bottle
-                func_8002F434(&this->actor, play, GI_MAX, 60.0f, 30.0f)) {
+                Actor_OfferGetItem(&this->actor, play, GI_MAX, 60.0f, 30.0f)) {
                 D_80A7DEB4++;
             }
         }

--- a/soh/src/overlays/actors/ovl_En_Ishi/z_en_ishi.c
+++ b/soh/src/overlays/actors/ovl_En_Ishi/z_en_ishi.c
@@ -379,9 +379,9 @@ void EnIshi_Wait(EnIshi* this, PlayState* play) {
             if (this->actor.xzDistToPlayer < 90.0f) {
                 // GI_NONE in these cases allows the player to lift the actor
                 if (type == ROCK_LARGE) {
-                    func_8002F434(&this->actor, play, GI_NONE, 80.0f, 20.0f);
+                    Actor_OfferGetItem(&this->actor, play, GI_NONE, 80.0f, 20.0f);
                 } else {
-                    func_8002F434(&this->actor, play, GI_NONE, 50.0f, 10.0f);
+                    Actor_OfferGetItem(&this->actor, play, GI_NONE, 50.0f, 10.0f);
                 }
             }
         }

--- a/soh/src/overlays/actors/ovl_En_Js/z_en_js.c
+++ b/soh/src/overlays/actors/ovl_En_Js/z_en_js.c
@@ -136,7 +136,7 @@ void func_80A89160(EnJs* this, PlayState* play) {
         GetItemEntry itemEntry = ItemTable_Retrieve(GI_BOMBCHUS_10);
         gSaveContext.pendingSale = itemEntry.itemId;
         gSaveContext.pendingSaleMod = itemEntry.modIndex;
-        func_8002F434(&this->actor, play, GI_BOMBCHUS_10, 10000.0f, 50.0f);
+        Actor_OfferGetItem(&this->actor, play, GI_BOMBCHUS_10, 10000.0f, 50.0f);
     }
 }
 

--- a/soh/src/overlays/actors/ovl_En_Ko/z_en_ko.c
+++ b/soh/src/overlays/actors/ovl_En_Ko/z_en_ko.c
@@ -1215,7 +1215,7 @@ void func_80A99504(EnKo* this, PlayState* play) {
         this->actor.parent = NULL;
         this->actionFunc = func_80A99560;
     } else {
-        func_8002F434(&this->actor, play, GI_SAW, 120.0f, 10.0f);
+        Actor_OfferGetItem(&this->actor, play, GI_SAW, 120.0f, 10.0f);
     }
 }
 

--- a/soh/src/overlays/actors/ovl_En_Kz/z_en_kz.c
+++ b/soh/src/overlays/actors/ovl_En_Kz/z_en_kz.c
@@ -463,7 +463,7 @@ void EnKz_SetupGetItem(EnKz* this, PlayState* play) {
         getItemId = this->isTrading ? GI_FROG : GI_TUNIC_ZORA;
         yRange = fabsf(this->actor.yDistToPlayer) + 1.0f;
         xzRange = this->actor.xzDistToPlayer + 1.0f;
-        func_8002F434(&this->actor, play, getItemId, xzRange, yRange);
+        Actor_OfferGetItem(&this->actor, play, getItemId, xzRange, yRange);
     }
 }
 

--- a/soh/src/overlays/actors/ovl_En_Ma1/z_en_ma1.c
+++ b/soh/src/overlays/actors/ovl_En_Ma1/z_en_ma1.c
@@ -335,7 +335,7 @@ void func_80AA0EA0(EnMa1* this, PlayState* play) {
         this->actor.parent = NULL;
         this->actionFunc = func_80AA0EFC;
     } else {
-        func_8002F434(&this->actor, play, GI_WEIRD_EGG, 120.0f, 10.0f);
+        Actor_OfferGetItem(&this->actor, play, GI_WEIRD_EGG, 120.0f, 10.0f);
     }
 }
 

--- a/soh/src/overlays/actors/ovl_En_Mk/z_en_mk.c
+++ b/soh/src/overlays/actors/ovl_En_Mk/z_en_mk.c
@@ -102,7 +102,7 @@ void func_80AACA94(EnMk* this, PlayState* play) {
             gSaveContext.eventInf[1] &= ~1;
         }
     } else {
-        func_8002F434(&this->actor, play, GI_EYEDROPS, 10000.0f, 50.0f);
+        Actor_OfferGetItem(&this->actor, play, GI_EYEDROPS, 10000.0f, 50.0f);
     }
 }
 
@@ -110,7 +110,7 @@ void func_80AACB14(EnMk* this, PlayState* play) {
     if (Actor_TextboxIsClosing(&this->actor, play)) {
         this->actionFunc = func_80AACA94;
         if (GameInteractor_Should(GI_VB_TRADE_FROG, true, this)) {
-            func_8002F434(&this->actor, play, GI_EYEDROPS, 10000.0f, 50.0f);
+            Actor_OfferGetItem(&this->actor, play, GI_EYEDROPS, 10000.0f, 50.0f);
         }
     }
 }
@@ -205,7 +205,7 @@ void func_80AACFA0(EnMk* this, PlayState* play) {
         this->actionFunc = func_80AACA40;
         Flags_SetItemGetInf(ITEMGETINF_10);
     } else {
-        func_8002F434(&this->actor, play, GI_HEART_PIECE, 10000.0f, 50.0f);
+        Actor_OfferGetItem(&this->actor, play, GI_HEART_PIECE, 10000.0f, 50.0f);
     }
 }
 
@@ -213,7 +213,7 @@ void func_80AAD014(EnMk* this, PlayState* play) {
     if (Actor_TextboxIsClosing(&this->actor, play)) {
         this->actionFunc = func_80AACFA0;
         if (GameInteractor_Should(GI_VB_GIVE_ITEM_FROM_LAB_DIVE, true, this)) {
-            func_8002F434(&this->actor, play, GI_HEART_PIECE, 10000.0f, 50.0f);
+            Actor_OfferGetItem(&this->actor, play, GI_HEART_PIECE, 10000.0f, 50.0f);
         }
     }
 

--- a/soh/src/overlays/actors/ovl_En_Ms/z_en_ms.c
+++ b/soh/src/overlays/actors/ovl_En_Ms/z_en_ms.c
@@ -135,7 +135,7 @@ void EnMs_Talk(EnMs* this, PlayState* play) {
                 }
     
                 if (GameInteractor_Should(GI_VB_GIVE_ITEM_FROM_MAGIC_BEAN_SALESMAN, true, this)) {
-                    func_8002F434(&this->actor, play, GI_BEAN, 90.0f, 10.0f);
+                    Actor_OfferGetItem(&this->actor, play, GI_BEAN, 90.0f, 10.0f);
                     this->actionFunc = EnMs_Sell;
                 }
                 return;
@@ -156,7 +156,7 @@ void EnMs_Sell(EnMs* this, PlayState* play) {
         GetItemEntry entry = ItemTable_Retrieve(GI_BEAN);
         gSaveContext.pendingSaleMod = entry.modIndex;
         gSaveContext.pendingSale = entry.itemId;
-        func_8002F434(&this->actor, play, GI_BEAN, 90.0f, 10.0f);
+        Actor_OfferGetItem(&this->actor, play, GI_BEAN, 90.0f, 10.0f);
     }
 }
 

--- a/soh/src/overlays/actors/ovl_En_Niw/z_en_niw.c
+++ b/soh/src/overlays/actors/ovl_En_Niw/z_en_niw.c
@@ -467,7 +467,7 @@ void func_80AB6450(EnNiw* this, PlayState* play) {
         this->actionFunc = func_80AB6BF8;
     } else {
         // GI_NONE in this case allows the player to lift the actor
-        func_8002F434(&this->actor, play, GI_NONE, 25.0f, 10.0f);
+        Actor_OfferGetItem(&this->actor, play, GI_NONE, 25.0f, 10.0f);
         func_80AB5BF8(this, play, 1);
     }
 }

--- a/soh/src/overlays/actors/ovl_En_Niw_Lady/z_en_niw_lady.c
+++ b/soh/src/overlays/actors/ovl_En_Niw_Lady/z_en_niw_lady.c
@@ -314,7 +314,7 @@ void func_80ABA654(EnNiwLady* this, PlayState* play) {
 
             if (GameInteractor_Should(GI_VB_GIVE_ITEM_FROM_ANJU_AS_CHILD, true, this)) {
                 this->getItemId = GI_BOTTLE;
-                func_8002F434(&this->actor, play, GI_BOTTLE, 100.0f, 50.0f);
+                Actor_OfferGetItem(&this->actor, play, GI_BOTTLE, 100.0f, 50.0f);
             } else {
                 // Circumvent the item offer action
                 this->actionFunc = func_80ABAC84;
@@ -327,7 +327,7 @@ void func_80ABA654(EnNiwLady* this, PlayState* play) {
         }
         if (this->unk_26C == 1) {
             this->getItemId = GI_RUPEE_PURPLE;
-            func_8002F434(&this->actor, play, GI_RUPEE_PURPLE, 100.0f, 50.0f);
+            Actor_OfferGetItem(&this->actor, play, GI_RUPEE_PURPLE, 100.0f, 50.0f);
             this->actionFunc = func_80ABAC00;
         }
         this->actionFunc = func_80ABA244;
@@ -405,7 +405,7 @@ void func_80ABA9B8(EnNiwLady* this, PlayState* play) {
                 this->actor.parent = NULL;
 
                 if (GameInteractor_Should(GI_VB_GIVE_ITEM_FROM_ANJU_AS_ADULT, true, this)) {
-                    func_8002F434(&this->actor, play, GI_POCKET_EGG, 200.0f, 100.0f);
+                    Actor_OfferGetItem(&this->actor, play, GI_POCKET_EGG, 200.0f, 100.0f);
                     this->actionFunc = func_80ABAC00;
                 } else {
                     // Circumvent the item offer action
@@ -440,7 +440,7 @@ void func_80ABAB08(EnNiwLady* this, PlayState* play) {
                 Message_CloseTextbox(play);
                 this->actor.parent = NULL;
                 if (GameInteractor_Should(GI_VB_TRADE_POCKET_CUCCO, true, this)) {
-                    func_8002F434(&this->actor, play, GI_COJIRO, 200.0f, 100.0f);
+                    Actor_OfferGetItem(&this->actor, play, GI_COJIRO, 200.0f, 100.0f);
                     this->actionFunc = func_80ABAC00;
                 } else {
                     // Circumvent the item offer action
@@ -471,7 +471,7 @@ void func_80ABAC00(EnNiwLady* this, PlayState* play) {
         if (LINK_IS_ADULT) {
             getItemId = !Flags_GetItemGetInf(ITEMGETINF_2C) ? GI_POCKET_EGG : GI_COJIRO;
         }
-        func_8002F434(&this->actor, play, getItemId, 200.0f, 100.0f);
+        Actor_OfferGetItem(&this->actor, play, getItemId, 200.0f, 100.0f);
     }
 }
 

--- a/soh/src/overlays/actors/ovl_En_Ossan/z_en_ossan.c
+++ b/soh/src/overlays/actors/ovl_En_Ossan/z_en_ossan.c
@@ -1389,7 +1389,7 @@ void EnOssan_GiveItemWithFanfare(PlayState* play, EnOssan* this) {
 
     osSyncPrintf("\n" VT_FGCOL(YELLOW) "初めて手にいれた！！" VT_RST "\n\n");
     if (!IS_RANDO) {
-        func_8002F434(&this->actor, play, this->shelfSlots[this->cursorIndex]->getItemId, 120.0f, 120.0f);
+        Actor_OfferGetItem(&this->actor, play, this->shelfSlots[this->cursorIndex]->getItemId, 120.0f, 120.0f);
     } else {
         ShopItemIdentity shopItemIdentity = Randomizer_IdentifyShopItem(play->sceneNum, this->cursorIndex);
         // en_ossan/en_girla are also used for the happy mask shop, which never has randomized items
@@ -1398,7 +1398,7 @@ void EnOssan_GiveItemWithFanfare(PlayState* play, EnOssan* this) {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(shopItemIdentity.randomizerCheck, shopItemIdentity.ogItemId);
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, 120.0f, 120.0f);
         } else {
-            func_8002F434(&this->actor, play, this->shelfSlots[this->cursorIndex]->getItemId, 120.0f, 120.0f);
+            Actor_OfferGetItem(&this->actor, play, this->shelfSlots[this->cursorIndex]->getItemId, 120.0f, 120.0f);
         }
     }
     play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
@@ -1736,7 +1736,7 @@ void EnOssan_State_GiveItemWithFanfare(EnOssan* this, PlayState* play, Player* p
         return;
     }
     if (!IS_RANDO) {
-        func_8002F434(&this->actor, play, this->shelfSlots[this->cursorIndex]->getItemId, 120.0f, 120.0f);
+        Actor_OfferGetItem(&this->actor, play, this->shelfSlots[this->cursorIndex]->getItemId, 120.0f, 120.0f);
     } else {
         ShopItemIdentity shopItemIdentity = Randomizer_IdentifyShopItem(play->sceneNum, this->cursorIndex);
         // en_ossan/en_girla are also used for the happy mask shop, which never has randomized items
@@ -1746,7 +1746,7 @@ void EnOssan_State_GiveItemWithFanfare(EnOssan* this, PlayState* play, Player* p
                 Randomizer_GetItemFromKnownCheck(shopItemIdentity.randomizerCheck, shopItemIdentity.ogItemId);
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, 120.0f, 120.0f);
         } else {
-            func_8002F434(&this->actor, play, this->shelfSlots[this->cursorIndex]->getItemId, 120.0f, 120.0f);
+            Actor_OfferGetItem(&this->actor, play, this->shelfSlots[this->cursorIndex]->getItemId, 120.0f, 120.0f);
         }
     }
 }

--- a/soh/src/overlays/actors/ovl_En_Skj/z_en_skj.c
+++ b/soh/src/overlays/actors/ovl_En_Skj/z_en_skj.c
@@ -1040,7 +1040,7 @@ void EnSkj_SariaSongTalk(EnSkj* this, PlayState* play) {
         } else {
             func_80AFFE24(this);
             if (!IS_RANDO) {
-                func_8002F434(&this->actor, play, GI_HEART_PIECE, EnSkj_GetItemXzRange(this), EnSkj_GetItemYRange(this));
+                Actor_OfferGetItem(&this->actor, play, GI_HEART_PIECE, EnSkj_GetItemXzRange(this), EnSkj_GetItemYRange(this));
             } else {
                 GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_LW_SKULL_KID, GI_HEART_PIECE);
                 GiveItemEntryFromActor(&this->actor, play, getItemEntry, EnSkj_GetItemXzRange(this), EnSkj_GetItemYRange(this));
@@ -1059,7 +1059,7 @@ void func_80AFFE44(EnSkj* this, PlayState* play) {
         EnSkj_SetupPostSariasSong(this);
     } else {
         if (!IS_RANDO) {
-            func_8002F434(&this->actor, play, GI_HEART_PIECE, EnSkj_GetItemXzRange(this), EnSkj_GetItemYRange(this));
+            Actor_OfferGetItem(&this->actor, play, GI_HEART_PIECE, EnSkj_GetItemXzRange(this), EnSkj_GetItemYRange(this));
         } else {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_LW_SKULL_KID, GI_HEART_PIECE);
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, EnSkj_GetItemXzRange(this), EnSkj_GetItemYRange(this));
@@ -1559,7 +1559,7 @@ void EnSkj_WaitToGiveReward(EnSkj* this, PlayState* play) {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_LW_OCARINA_MEMORY_GAME, GI_HEART_PIECE);
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, 26.0f, 26.0f);
         } else {
-            func_8002F434(&this->actor, play, sOcarinaGameRewards[gSaveContext.ocarinaGameRoundNum], 26.0f, 26.0f);
+            Actor_OfferGetItem(&this->actor, play, sOcarinaGameRewards[gSaveContext.ocarinaGameRoundNum], 26.0f, 26.0f);
         }
 
         this->actionFunc = EnSkj_GiveOcarinaGameReward;
@@ -1575,7 +1575,7 @@ void EnSkj_GiveOcarinaGameReward(EnSkj* this, PlayState* play) {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_LW_OCARINA_MEMORY_GAME, GI_HEART_PIECE);
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, 26.0f, 26.0f);
         } else {
-            func_8002F434(&this->actor, play, sOcarinaGameRewards[gSaveContext.ocarinaGameRoundNum], 26.0f, 26.0f);
+            Actor_OfferGetItem(&this->actor, play, sOcarinaGameRewards[gSaveContext.ocarinaGameRoundNum], 26.0f, 26.0f);
         }
     }
 }

--- a/soh/src/overlays/actors/ovl_En_Sth/z_en_sth.c
+++ b/soh/src/overlays/actors/ovl_En_Sth/z_en_sth.c
@@ -302,7 +302,7 @@ void EnSth_GivePlayerItem(EnSth* this, PlayState* play) {
     }
 
     if (!IS_RANDO || getItemEntry.getItemId == GI_NONE) {
-        func_8002F434(&this->actor, play, getItemId, 10000.0f, 50.0f);
+        Actor_OfferGetItem(&this->actor, play, getItemId, 10000.0f, 50.0f);
     } else {
         GiveItemEntryFromActor(&this->actor, play, getItemEntry, 10000.0f, 50.0f);
     }

--- a/soh/src/overlays/actors/ovl_En_Syateki_Man/z_en_syateki_man.c
+++ b/soh/src/overlays/actors/ovl_En_Syateki_Man/z_en_syateki_man.c
@@ -397,7 +397,7 @@ void EnSyatekiMan_EndGame(EnSyatekiMan* this, PlayState* play) {
                         }
                     }
                     if (!IS_RANDO || this->getItemEntry.getItemId == GI_NONE) {
-                        func_8002F434(&this->actor, play, this->getItemId, 2000.0f, 1000.0f);
+                        Actor_OfferGetItem(&this->actor, play, this->getItemId, 2000.0f, 1000.0f);
                     } else {
                         GiveItemEntryFromActor(&this->actor, play, this->getItemEntry, 2000.0f, 1000.0f);
                     }
@@ -434,7 +434,7 @@ void EnSyatekiMan_GivePrize(EnSyatekiMan* this, PlayState* play) {
         this->actionFunc = EnSyatekiMan_FinishPrize;
     } else {
         if (!IS_RANDO || this->getItemEntry.getItemId == GI_NONE) {
-            func_8002F434(&this->actor, play, this->getItemId, 2000.0f, 1000.0f);
+            Actor_OfferGetItem(&this->actor, play, this->getItemId, 2000.0f, 1000.0f);
         } else {
             GiveItemEntryFromActor(&this->actor, play, this->getItemEntry, 2000.0f, 1000.0f);
         }

--- a/soh/src/overlays/actors/ovl_En_Ta/z_en_ta.c
+++ b/soh/src/overlays/actors/ovl_En_Ta/z_en_ta.c
@@ -877,10 +877,10 @@ void func_80B15E80(EnTa* this, PlayState* play) {
         }
         this->unk_2E0 &= ~0x2;
     } else if (this->unk_2E0 & 2) {
-        func_8002F434(&this->actor, play, GI_MILK, 10000.0f, 50.0f);
+        Actor_OfferGetItem(&this->actor, play, GI_MILK, 10000.0f, 50.0f);
     } else {
         if (!IS_RANDO) {
-            func_8002F434(&this->actor, play, GI_MILK_BOTTLE, 10000.0f, 50.0f);
+            Actor_OfferGetItem(&this->actor, play, GI_MILK_BOTTLE, 10000.0f, 50.0f);
         } else {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_LLR_TALONS_CHICKENS, GI_MILK_BOTTLE);
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, 10000.0f, 50.0f);
@@ -895,7 +895,7 @@ void func_80B15F54(EnTa* this, PlayState* play) {
         this->unk_2E0 &= ~0x2;
         func_80B13AA0(this, func_80B15E80, func_80B16938);
         if (!IS_RANDO) {
-            func_8002F434(&this->actor, play, GI_MILK_BOTTLE, 10000.0f, 50.0f);
+            Actor_OfferGetItem(&this->actor, play, GI_MILK_BOTTLE, 10000.0f, 50.0f);
         } else {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_LLR_TALONS_CHICKENS, GI_MILK_BOTTLE);
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, 10000.0f, 50.0f);
@@ -923,7 +923,7 @@ void func_80B15FE8(EnTa* this, PlayState* play) {
                         GetItemEntry itemEntry = ItemTable_Retrieve(GI_MILK);
                         gSaveContext.pendingSale = itemEntry.itemId;
                         gSaveContext.pendingSaleMod = itemEntry.modIndex;
-                        func_8002F434(&this->actor, play, GI_MILK, 10000.0f, 50.0f);
+                        Actor_OfferGetItem(&this->actor, play, GI_MILK, 10000.0f, 50.0f);
                         break;
                 }
                 break;
@@ -1014,7 +1014,7 @@ void func_80B1642C(EnTa* this, PlayState* play) {
             Message_CloseTextbox(play);
             this->unk_2E0 |= 2;
             func_80B13AA0(this, func_80B15E80, func_80B16938);
-            func_8002F434(&this->actor, play, GI_MILK, 10000.0f, 50.0f);
+            Actor_OfferGetItem(&this->actor, play, GI_MILK, 10000.0f, 50.0f);
         } else {
             Message_ContinueTextbox(play, 0x208A);
             func_80B13AA0(this, func_80B15E28, func_80B16938);

--- a/soh/src/overlays/actors/ovl_En_Takara_Man/z_en_takara_man.c
+++ b/soh/src/overlays/actors/ovl_En_Takara_Man/z_en_takara_man.c
@@ -147,7 +147,7 @@ void func_80B17934(EnTakaraMan* this, PlayState* play) {
                     Rupees_ChangeBy(-10);
                     this->unk_214 = 1;
                     this->actor.parent = NULL;
-                    func_8002F434(&this->actor, play, GI_DOOR_KEY, 2000.0f, 1000.0f);
+                    Actor_OfferGetItem(&this->actor, play, GI_DOOR_KEY, 2000.0f, 1000.0f);
                     this->actionFunc = func_80B17A6C;
                 } else {
                     Message_CloseTextbox(play);
@@ -172,7 +172,7 @@ void func_80B17A6C(EnTakaraMan* this, PlayState* play) {
     if (Actor_HasParent(&this->actor, play)) {
         this->actionFunc = func_80B17AC4;
     } else {
-        func_8002F434(&this->actor, play, GI_DOOR_KEY, 2000.0f, 1000.0f);
+        Actor_OfferGetItem(&this->actor, play, GI_DOOR_KEY, 2000.0f, 1000.0f);
     }
 }
 

--- a/soh/src/overlays/actors/ovl_En_Toryo/z_en_toryo.c
+++ b/soh/src/overlays/actors/ovl_En_Toryo/z_en_toryo.c
@@ -317,7 +317,7 @@ void func_80B20768(EnToryo* this, PlayState* play) {
             this->unk_1E4 = 5;
             Flags_SetRandomizerInf(RAND_INF_ADULT_TRADES_GV_TRADE_SAW);
         } else {
-            func_8002F434(&this->actor, play, GI_SWORD_BROKEN, 100.0f, 10.0f);
+            Actor_OfferGetItem(&this->actor, play, GI_SWORD_BROKEN, 100.0f, 10.0f);
         }
         return;
     }

--- a/soh/src/overlays/actors/ovl_En_Zl1/z_en_zl1.c
+++ b/soh/src/overlays/actors/ovl_En_Zl1/z_en_zl1.c
@@ -510,7 +510,7 @@ void func_80B4BF2C(EnZl1* this, PlayState* play) {
             if ((Message_GetState(msgCtx) == TEXT_STATE_EVENT) && Message_ShouldAdvance(play)) {
                 this->actor.textId = 0xFFFF;
                 play->talkWithPlayer(play, &this->actor);
-                func_8002F434(&this->actor, play, GI_LETTER_ZELDA, 120.0f, 10.0f);
+                Actor_OfferGetItem(&this->actor, play, GI_LETTER_ZELDA, 120.0f, 10.0f);
                 play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
                 play->msgCtx.stateTimer = 4;
                 this->unk_1E2++;
@@ -525,7 +525,7 @@ void func_80B4BF2C(EnZl1* this, PlayState* play) {
                 this->actor.parent = NULL;
                 this->unk_1E2++;
             } else {
-                func_8002F434(&this->actor, play, GI_LETTER_ZELDA, 120.0f, 10.0f);
+                Actor_OfferGetItem(&this->actor, play, GI_LETTER_ZELDA, 120.0f, 10.0f);
             }
             break;
         case 3:

--- a/soh/src/overlays/actors/ovl_En_Zl4/z_en_zl4.c
+++ b/soh/src/overlays/actors/ovl_En_Zl4/z_en_zl4.c
@@ -1109,7 +1109,7 @@ s32 EnZl4_CsMakePlan(EnZl4* this, PlayState* play) {
                 this->talkState = 7;
                 play->talkWithPlayer(play, &this->actor);
                 if (GameInteractor_Should(GI_VB_GIVE_ITEM_ZELDAS_LETTER, true, NULL)) {
-                    func_8002F434(&this->actor, play, GI_LETTER_ZELDA, fabsf(this->actor.xzDistToPlayer) + 1.0f,
+                    Actor_OfferGetItem(&this->actor, play, GI_LETTER_ZELDA, fabsf(this->actor.xzDistToPlayer) + 1.0f,
                                 fabsf(this->actor.yDistToPlayer) + 1.0f);
                 }
                 play->msgCtx.stateTimer = 4;
@@ -1121,7 +1121,7 @@ s32 EnZl4_CsMakePlan(EnZl4* this, PlayState* play) {
                 Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ZL4_ANIM_0);
                 this->talkState++;
             } else {
-                func_8002F434(&this->actor, play, GI_LETTER_ZELDA, fabsf(this->actor.xzDistToPlayer) + 1.0f,
+                Actor_OfferGetItem(&this->actor, play, GI_LETTER_ZELDA, fabsf(this->actor.xzDistToPlayer) + 1.0f,
                               fabsf(this->actor.yDistToPlayer) + 1.0f);
             }
             // no break here is required for matching

--- a/soh/src/overlays/actors/ovl_Fishing/z_fishing.c
+++ b/soh/src/overlays/actors/ovl_Fishing/z_fishing.c
@@ -5160,7 +5160,7 @@ void Fishing_HandleOwnerDialog(Fishing* this, PlayState* play) {
 
                 this->actor.parent = NULL;
                 if (!IS_RANDO || getItemEntry.getItemId == GI_NONE) {
-                    func_8002F434(&this->actor, play, getItemId, 2000.0f, 1000.0f);
+                    Actor_OfferGetItem(&this->actor, play, getItemId, 2000.0f, 1000.0f);
                 } else {
                     GiveItemEntryFromActor(&this->actor, play, getItemEntry, 2000.0f, 1000.0f);
                 }
@@ -5215,7 +5215,7 @@ void Fishing_HandleOwnerDialog(Fishing* this, PlayState* play) {
                 this->stateAndTimer = 24;
             } else {
                 if (!IS_RANDO) {
-                    func_8002F434(&this->actor, play, GI_SCALE_GOLD, 2000.0f, 1000.0f);
+                    Actor_OfferGetItem(&this->actor, play, GI_SCALE_GOLD, 2000.0f, 1000.0f);
                 } else {
                     GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_LH_ADULT_FISHING, GI_SCALE_GOLD);
                     GiveItemEntryFromActor(&this->actor, play, getItemEntry, 2000.0f, 1000.0f);

--- a/soh/src/overlays/actors/ovl_Item_B_Heart/z_item_b_heart.c
+++ b/soh/src/overlays/actors/ovl_Item_B_Heart/z_item_b_heart.c
@@ -59,7 +59,7 @@ void ItemBHeart_Update(Actor* thisx, PlayState* play) {
         Flags_SetCollectible(play, 0x1F);
         Actor_Kill(&this->actor);
     } else {
-        func_8002F434(&this->actor, play, GI_HEART_CONTAINER_2, 30.0f, 40.0f);
+        Actor_OfferGetItem(&this->actor, play, GI_HEART_CONTAINER_2, 30.0f, 40.0f);
     }
 }
 

--- a/soh/src/overlays/actors/ovl_Item_Etcetera/z_item_etcetera.c
+++ b/soh/src/overlays/actors/ovl_Item_Etcetera/z_item_etcetera.c
@@ -134,7 +134,7 @@ void func_80B85824(ItemEtcetera* this, PlayState* play) {
         Actor_Kill(&this->actor);
     } else {
         if (!IS_RANDO) {
-            func_8002F434(&this->actor, play, this->getItemId, 30.0f, 50.0f);
+            Actor_OfferGetItem(&this->actor, play, this->getItemId, 30.0f, 50.0f);
         } else {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_LH_SUN, GI_ARROW_FIRE);
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, 30.0f, 50.0f);
@@ -157,7 +157,7 @@ void func_80B858B4(ItemEtcetera* this, PlayState* play) {
         if (0) {} // Necessary to match
 
         if (!IS_RANDO) {
-            func_8002F434(&this->actor, play, this->getItemId, 30.0f, 50.0f);
+            Actor_OfferGetItem(&this->actor, play, this->getItemId, 30.0f, 50.0f);
         } else {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_LH_UNDERWATER_ITEM, GI_LETTER_RUTO);
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, 30.0f, 50.0f);

--- a/soh/src/overlays/actors/ovl_Item_Ocarina/z_item_ocarina.c
+++ b/soh/src/overlays/actors/ovl_Item_Ocarina/z_item_ocarina.c
@@ -190,7 +190,7 @@ void ItemOcarina_WaitInWater(ItemOcarina* this, PlayState* play) {
         this->actor.draw = NULL;
     } else {
         if (GameInteractor_Should(GI_VB_GIVE_ITEM_OCARINA_OF_TIME, true, NULL)) {
-            func_8002F434(&this->actor, play, GI_OCARINA_OOT, 30.0f, 50.0f);
+            Actor_OfferGetItem(&this->actor, play, GI_OCARINA_OOT, 30.0f, 50.0f);
         }
 
         if ((play->gameplayFrames & 13) == 0) {

--- a/soh/src/overlays/actors/ovl_Item_Shield/z_item_shield.c
+++ b/soh/src/overlays/actors/ovl_Item_Shield/z_item_shield.c
@@ -103,7 +103,7 @@ void func_80B86AC8(ItemShield* this, PlayState* play) {
         Actor_Kill(&this->actor);
         return;
     }
-    func_8002F434(&this->actor, play, GI_SHIELD_DEKU, 30.0f, 50.0f);
+    Actor_OfferGetItem(&this->actor, play, GI_SHIELD_DEKU, 30.0f, 50.0f);
     Actor_UpdateBgCheckInfo(play, &this->actor, 10.0f, 10.0f, 0.0f, 5);
     if (this->actor.bgCheckFlags & 1) {
         this->timer--;
@@ -125,7 +125,7 @@ void func_80B86BC8(ItemShield* this, PlayState* play) {
         Actor_Kill(&this->actor);
         return;
     }
-    func_8002F434(&this->actor, play, GI_SHIELD_DEKU, 30.0f, 50.0f);
+    Actor_OfferGetItem(&this->actor, play, GI_SHIELD_DEKU, 30.0f, 50.0f);
     if (this->collider.base.acFlags & AC_HIT) {
         ItemShield_SetupAction(this, func_80B86AC8);
         this->actor.velocity.y = 4.0f;

--- a/soh/src/overlays/actors/ovl_Obj_Tsubo/z_obj_tsubo.c
+++ b/soh/src/overlays/actors/ovl_Obj_Tsubo/z_obj_tsubo.c
@@ -274,7 +274,7 @@ void ObjTsubo_Idle(ObjTsubo* this, PlayState* play) {
             phi_v1 = ABS(temp_v0);
             if (phi_v1 >= 0x5556) {
                 // GI_NONE in this case allows the player to lift the actor
-                func_8002F434(&this->actor, play, GI_NONE, 30.0f, 30.0f);
+                Actor_OfferGetItem(&this->actor, play, GI_NONE, 30.0f, 30.0f);
             }
         }
     }


### PR DESCRIPTION
Renames all instances of `func_8002F434` to `Actor_OfferGetItem` to match ZRET/oot name and make item code more readable.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1234901186.zip)
  - [soh-windows.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1234918906.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1234919286.zip)
  - [soh-wiiu.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1234920464.zip)
  - [soh-linux-performance.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1234924429.zip)
  - [soh-switch.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1234925322.zip)
  - [soh-mac.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1234941837.zip)
<!--- section:artifacts:end -->