### PR TITLE
Fix timesaver hook conditions to ensure dampe gives reward in rando

### DIFF
--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -483,14 +483,14 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, void*
             }
             break;
         case GI_VB_BE_VALID_GRAVEDIGGING_SPOT:
-            if (CVarGetInteger("gDampeWin", 0)) {
+            if (CVarGetInteger("gDampeWin", 0) || IS_RANDO) {
                 EnTk *enTk = static_cast<EnTk*>(opt);
                 enTk->validDigHere = true;
                 *should = true;
             }
             break;
         case GI_VB_BE_DAMPE_GRAVEDIGGING_GRAND_PRIZE:
-            if (CVarGetInteger("gDampeWin", 0)) {
+            if (CVarGetInteger("gDampeWin", 0) || IS_RANDO) {
                 EnTk *enTk = static_cast<EnTk*>(opt);
                 enTk->currentReward = 3;
                 *should = true;


### PR DESCRIPTION
The "Always win dampe gravedigging game" enhancement is shown as defaulted in rando but the new hooks did not account for this.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1240188688.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1240212477.zip)
  - [soh-wiiu.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1240213253.zip)
  - [soh-windows.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1240213468.zip)
  - [soh-switch.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1240219075.zip)
  - [soh-linux-performance.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1240220053.zip)
  - [soh-mac.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1240258368.zip)
<!--- section:artifacts:end -->