### PR TITLE
lil bit of vb tower escape

### DIFF
--- a/soh/soh/Enhancements/game-interactor/GameInteractor.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor.h
@@ -258,6 +258,8 @@ typedef enum {
     GI_VB_PLAY_DOOR_OF_TIME_CS,
     GI_VB_PLAY_RAINBOW_BRIDGE_CS,
 
+    GI_VB_BEGIN_TOWER_ESCAPE,
+
     /*** Give Items ***/
 
     // Opt: *EnBox

--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -674,6 +674,15 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, void*
             }
             break;
         }
+        case GI_VB_BEGIN_TOWER_ESCAPE: {
+            if ((IS_RANDO && RAND_GET_OPTION(RSK_SKIP_TOWER_ESCAPE)) ||
+                 IS_BOSS_RUSH) {
+                Flags_SetEventChkInf(EVENTCHKINF_WATCHED_GANONS_CASTLE_COLLAPSE_CAUGHT_BY_GERUDO);
+                gPlayState->nextEntranceIndex = ENTR_GANON_BOSS_0;
+                *should = false;
+            }
+            break;
+        }
     }
 }
 

--- a/soh/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
+++ b/soh/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
@@ -12,6 +12,7 @@
 
 #include "soh/frame_interpolation.h"
 #include "soh/Enhancements/boss-rush/BossRush.h"
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #include <string.h>
 
@@ -1539,11 +1540,7 @@ void BossGanon_DeathAndTowerCutscene(BossGanon* this, PlayState* play) {
 
             if (this->csTimer == 180) {
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                if ((IS_RANDO && Randomizer_GetSettingValue(RSK_SKIP_TOWER_ESCAPE) || IS_BOSS_RUSH)) {
-                    Flags_SetEventChkInf(EVENTCHKINF_WATCHED_GANONS_CASTLE_COLLAPSE_CAUGHT_BY_GERUDO);
-                    play->nextEntranceIndex = ENTR_GANON_BOSS_0;
-                }
-                else {
+                if (GameInteractor_Should(GI_VB_BEGIN_TOWER_ESCAPE, true, NULL)) {
                     play->nextEntranceIndex = ENTR_GANONS_TOWER_COLLAPSE_EXTERIOR_0;
                 }
                 play->transitionType = TRANS_TYPE_FADE_WHITE_FAST;


### PR DESCRIPTION
this just replicates the logic we had for skipping but puts it in the timesaver hook handler instead of directly in z_boss_ganon

i figure we want to make this part of a cvar and what not so people can skip in vanilla but i figure this at least covers the cleanup portion of the work

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1428528212.zip)
  - [soh-windows.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1428554976.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1428558586.zip)
  - [soh-linux-performance.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1428565900.zip)
  - [soh-switch.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1428571143.zip)
  - [soh-mac.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1428580593.zip)
<!--- section:artifacts:end -->