### PR TITLE
Adds Quick Boss Death checkbox and implements Phantom Ganon's quick death

### DIFF
--- a/soh/soh/Enhancements/game-interactor/GameInteractor.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor.h
@@ -376,6 +376,10 @@ typedef enum {
     /*** Fixes ***/
     // Vanilla condition: false
     GI_VB_FIX_SAW_SOFTLOCK,
+
+    /*** Quick Boss Deaths ***/
+    // Vanilla condition: true
+    GI_VB_PHANTOM_GANON_DEATH_SCENE,
 } GIVanillaBehavior;
 
 #ifdef __cplusplus

--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -24,6 +24,8 @@ extern "C" {
 #include "src/overlays/actors/ovl_Bg_Dy_Yoseizo/z_bg_dy_yoseizo.h"
 #include "src/overlays/actors/ovl_En_Dnt_Demo/z_en_dnt_demo.h"
 #include "src/overlays/actors/ovl_En_Po_Sisters/z_en_po_sisters.h"
+#include <overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.h>
+#include <objects/object_gnd/object_gnd.h>
 extern SaveContext gSaveContext;
 extern PlayState* gPlayState;
 extern int32_t D_8011D3AC;
@@ -716,6 +718,31 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, void*
             if (CVarGetInteger("gTimeSavers.SkipCutscene.Story", IS_RANDO)) {
                 *should = false;
                 func_800F595C(NA_BGM_BRIDGE_TO_GANONS);
+            }
+            break;
+        }
+        case GI_VB_PHANTOM_GANON_DEATH_SCENE: {
+            if (CVarGetInteger("gTimeSavers.SkipCutscene.QuickBossDeaths", IS_RANDO || IS_BOSS_RUSH)) {
+                *should = false;
+                BossGanondrof* pg = static_cast<BossGanondrof*>(opt);
+                Player* player = GET_PLAYER(gPlayState);
+                if (pg != nullptr && pg->work[GND_ACTION_STATE] == DEATH_SPASM) {
+                    // Skip to death scream animation and move ganondrof to middle
+                    pg->deathState = DEATH_SCREAM;
+                    pg->timers[0] = 50;
+                    AnimationHeader* screamAnim = (AnimationHeader*)gPhantomGanonScreamAnim;
+                    Animation_MorphToLoop(&pg->skelAnime, screamAnim, -10.0f);
+                    pg->actor.world.pos.x = GND_BOSSROOM_CENTER_X;
+                    pg->actor.world.pos.y = GND_BOSSROOM_CENTER_Y + 83.0f;
+                    pg->actor.world.pos.z = GND_BOSSROOM_CENTER_Z;
+                    pg->actor.shape.rot.y = 0;
+                    pg->work[GND_BODY_DECAY_INDEX] = 0;
+                    Audio_PlayActorSound2(&pg->actor, NA_SE_EN_FANTOM_LAST);
+
+                    // Move Player out of the center of the room
+                    player->actor.world.pos.x = GND_BOSSROOM_CENTER_X - 200.0f;
+                    player->actor.world.pos.z = GND_BOSSROOM_CENTER_Z;
+                }
             }
             break;
         }

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -581,6 +581,7 @@ void DrawEnhancementsMenu() {
                     CVarGetInteger("gTimeSavers.SkipCutscene.Story", IS_RANDO) &&
                     CVarGetInteger("gTimeSavers.SkipCutscene.LearnSong", IS_RANDO) &&
                     CVarGetInteger("gTimeSavers.SkipCutscene.BossIntro", IS_RANDO) &&
+                    CVarGetInteger("gTimeSavers.SkipCutscene.QuickBossDeaths", IS_RANDO) &&
                     CVarGetInteger("gTimeSavers.SkipCutscene.OnePoint", IS_RANDO) &&
                     CVarGetInteger("gTimeSavers.NoForcedDialog", IS_RANDO) &&
                     CVarGetInteger("gTimeSavers.SkipOwlInteractions", IS_RANDO) &&
@@ -592,6 +593,7 @@ void DrawEnhancementsMenu() {
                     CVarGetInteger("gTimeSavers.SkipCutscene.Story", IS_RANDO) ||
                     CVarGetInteger("gTimeSavers.SkipCutscene.LearnSong", IS_RANDO) ||
                     CVarGetInteger("gTimeSavers.SkipCutscene.BossIntro", IS_RANDO) ||
+                    CVarGetInteger("gTimeSavers.SkipCutscene.QuickBossDeaths", IS_RANDO) ||
                     CVarGetInteger("gTimeSavers.SkipCutscene.OnePoint", IS_RANDO) ||
                     CVarGetInteger("gTimeSavers.NoForcedDialog", IS_RANDO) ||
                     CVarGetInteger("gTimeSavers.SkipOwlInteractions", IS_RANDO) ||
@@ -608,6 +610,7 @@ void DrawEnhancementsMenu() {
                         CVarSetInteger("gTimeSavers.SkipCutscene.Story", 1);
                         CVarSetInteger("gTimeSavers.SkipCutscene.LearnSong", 1);
                         CVarSetInteger("gTimeSavers.SkipCutscene.BossIntro", 1);
+                        CVarSetInteger("gTimeSavers.SkipCutscene.QuickBossDeaths", 1);
                         CVarSetInteger("gTimeSavers.SkipCutscene.OnePoint", 1);
                         CVarSetInteger("gTimeSavers.NoForcedDialog", 1);
                         CVarSetInteger("gTimeSavers.SkipOwlInteractions", 1);
@@ -619,6 +622,7 @@ void DrawEnhancementsMenu() {
                         CVarSetInteger("gTimeSavers.SkipCutscene.Story", 0);
                         CVarSetInteger("gTimeSavers.SkipCutscene.LearnSong", 0);
                         CVarSetInteger("gTimeSavers.SkipCutscene.BossIntro", 0);
+                        CVarSetInteger("gTimeSavers.SkipCutscene.QuickBossDeaths", 0);
                         CVarSetInteger("gTimeSavers.SkipCutscene.OnePoint", 0);
                         CVarSetInteger("gTimeSavers.NoForcedDialog", 0);
                         CVarSetInteger("gTimeSavers.SkipOwlInteractions", 0);
@@ -633,6 +637,7 @@ void DrawEnhancementsMenu() {
                 UIWidgets::PaddedEnhancementCheckbox("Skip Story Cutscenes", "gTimeSavers.SkipCutscene.Story", false, false, false, "", UIWidgets::CheckboxGraphics::Cross, IS_RANDO);
                 UIWidgets::PaddedEnhancementCheckbox("Skip Song Cutscenes", "gTimeSavers.SkipCutscene.LearnSong", false, false, false, "", UIWidgets::CheckboxGraphics::Cross, IS_RANDO);
                 UIWidgets::PaddedEnhancementCheckbox("Skip Boss Introductions", "gTimeSavers.SkipCutscene.BossIntro", false, false, false, "", UIWidgets::CheckboxGraphics::Cross, IS_RANDO);
+                UIWidgets::PaddedEnhancementCheckbox("Quick Boss Deaths", "gTimeSavers.SkipCutscene.QuickBossDeaths", false, false, false, "", UIWidgets::CheckboxGraphics::Cross, IS_RANDO);
                 UIWidgets::PaddedEnhancementCheckbox("Skip One Point Cutscenes (Chests, Door Unlocks, etc)", "gTimeSavers.SkipCutscene.OnePoint", false, false, false, "", UIWidgets::CheckboxGraphics::Cross, IS_RANDO);
                 UIWidgets::PaddedEnhancementCheckbox("No Forced Dialog", "gTimeSavers.NoForcedDialog", false, false, false, "", UIWidgets::CheckboxGraphics::Cross, IS_RANDO);
                 UIWidgets::Tooltip("Prevent forced conversations with Navi or other NPCs");

--- a/soh/src/overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.h
+++ b/soh/src/overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.h
@@ -61,6 +61,23 @@ typedef enum {
     /* 13 */ GND_FLOAT_COUNT = 13
 } BossGanondrofF32Var;
 
+// Relocated from z_boss_ganondrof.c
+typedef enum {
+    /* 0 */ NOT_DEAD,
+    /* 1 */ DEATH_START,
+    /* 2 */ DEATH_THROES,
+    /* 3 */ DEATH_WARP,
+    /* 4 */ DEATH_SCREAM,
+    /* 5 */ DEATH_DISINTEGRATE,
+    /* 6 */ DEATH_FINISH
+} BossGanondrofDeathState;
+
+typedef enum {
+    /* 0 */ DEATH_SPASM,
+    /* 1 */ DEATH_LIMP,
+    /* 2 */ DEATH_HUNCHED
+} BossGanondrofDeathAction;
+
 typedef struct BossGanondrof {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ SkelAnime skelAnime;

--- a/soh/src/overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.h
+++ b/soh/src/overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.h
@@ -61,7 +61,7 @@ typedef enum {
     /* 13 */ GND_FLOAT_COUNT = 13
 } BossGanondrofF32Var;
 
-// Relocated from z_boss_ganondrof.c
+// SOH [Enhancements] Relocated from z_boss_ganondrof.c to use in time saver.
 typedef enum {
     /* 0 */ NOT_DEAD,
     /* 1 */ DEATH_START,


### PR DESCRIPTION
null

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1451883002.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1451923396.zip)
  - [soh-wiiu.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1451926076.zip)
  - [soh-windows.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1451926653.zip)
  - [soh-linux-performance.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1451931936.zip)
  - [soh-switch.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1451941426.zip)
  - [soh-mac.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1452038522.zip)
<!--- section:artifacts:end -->