### PR TITLE
Implements Twinrova Quick Death in VB Hooks

### DIFF
--- a/soh/soh/Enhancements/game-interactor/GameInteractor.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor.h
@@ -376,6 +376,10 @@ typedef enum {
     /*** Fixes ***/
     // Vanilla condition: false
     GI_VB_FIX_SAW_SOFTLOCK,
+
+    /*** Quick Boss Deaths ***/
+    // Vanilla condition: true
+    GI_VB_PHANTOM_GANON_DEATH_SCENE,
 } GIVanillaBehavior;
 
 #ifdef __cplusplus

--- a/soh/soh/Enhancements/game-interactor/GameInteractor.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor.h
@@ -381,6 +381,7 @@ typedef enum {
     // Vanilla condition: true
     GI_VB_PHANTOM_GANON_DEATH_SCENE,
     GI_VB_NABOORU_KNUCKLE_DEATH_SCENE,
+    GI_VB_TWINROVA_DEATH_SCENE,
 } GIVanillaBehavior;
 
 #ifdef __cplusplus

--- a/soh/soh/Enhancements/game-interactor/GameInteractor.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor.h
@@ -380,6 +380,7 @@ typedef enum {
     /*** Quick Boss Deaths ***/
     // Vanilla condition: true
     GI_VB_PHANTOM_GANON_DEATH_SCENE,
+    GI_VB_NABOORU_KNUCKLE_DEATH_SCENE,
 } GIVanillaBehavior;
 
 #ifdef __cplusplus

--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -24,6 +24,8 @@ extern "C" {
 #include "src/overlays/actors/ovl_Bg_Dy_Yoseizo/z_bg_dy_yoseizo.h"
 #include "src/overlays/actors/ovl_En_Dnt_Demo/z_en_dnt_demo.h"
 #include "src/overlays/actors/ovl_En_Po_Sisters/z_en_po_sisters.h"
+#include <overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.h>
+#include <objects/object_gnd/object_gnd.h>
 extern SaveContext gSaveContext;
 extern PlayState* gPlayState;
 extern int32_t D_8011D3AC;
@@ -716,6 +718,31 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, void*
             if (CVarGetInteger("gTimeSavers.SkipCutscene.Story", IS_RANDO)) {
                 *should = false;
                 func_800F595C(NA_BGM_BRIDGE_TO_GANONS);
+            }
+            break;
+        }
+        case GI_VB_PHANTOM_GANON_DEATH_SCENE: {
+            if (CVarGetInteger("gTimeSavers.SkipCutscene.QuickBossDeaths", IS_RANDO || IS_BOSS_RUSH)) {
+                *should = false;
+                BossGanondrof* pg = static_cast<BossGanondrof*>(opt);
+                Player* player = GET_PLAYER(gPlayState);
+                if (pg != nullptr && pg->work[GND_ACTION_STATE] == DEATH_SPASM) {
+                    // Skip to death scream animation and move ganondrof to middle
+                    pg->deathState = DEATH_SCREAM;
+                    pg->timers[0] = 50;
+                    AnimationHeader* screamAnim = (AnimationHeader*)gPhantomGanonScreamAnim;
+                    Animation_MorphToLoop(&pg->skelAnime, screamAnim, -10.0f);
+                    pg->actor.world.pos.x = GND_BOSSROOM_CENTER_X;
+                    pg->actor.world.pos.y = GND_BOSSROOM_CENTER_Y + 83.0f;
+                    pg->actor.world.pos.z = GND_BOSSROOM_CENTER_Z;
+                    pg->actor.shape.rot.y = 0;
+                    pg->work[GND_BODY_DECAY_INDEX] = 0;
+                    Audio_PlayActorSound2(&pg->actor, NA_SE_EN_FANTOM_LAST);
+
+                    // Move Player out of the center of the room
+                    player->actor.world.pos.x = GND_BOSSROOM_CENTER_X - 200.0f;
+                    player->actor.world.pos.z = GND_BOSSROOM_CENTER_Z;
+                }
             }
             break;
         }

--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -25,6 +25,7 @@ extern "C" {
 #include "src/overlays/actors/ovl_En_Dnt_Demo/z_en_dnt_demo.h"
 #include "src/overlays/actors/ovl_En_Po_Sisters/z_en_po_sisters.h"
 #include <overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.h>
+#include <overlays/actors/ovl_En_Ik/z_en_ik.h>
 #include <objects/object_gnd/object_gnd.h>
 extern SaveContext gSaveContext;
 extern PlayState* gPlayState;
@@ -745,6 +746,29 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, void*
                 }
             }
             break;
+        case GI_VB_NABOORU_KNUCKLE_DEATH_SCENE: {
+            EnIk* ik = static_cast<EnIk*>(opt);
+            if (CVarGetInteger("gTimeSavers.SkipCutscene.QuickBossDeaths", IS_RANDO)) {
+                // Because no CS in rando, we hide the death of the knuckle by spawning flames and kill the actor
+                if ((ik->actor.colChkInfo.health <= 10)) {
+                    s32 i;
+                    Vec3f pos;
+                    Vec3f sp7C = { 0.0f, 0.5f, 0.0f };
+                    int flameAmount = 100;
+
+                    for (i = flameAmount; i >= 0; i--) {
+                        pos.x = ik->actor.world.pos.x + Rand_CenteredFloat(120.0f);
+                        pos.z = ik->actor.world.pos.z + Rand_CenteredFloat(120.0f);
+                        pos.y = ik->actor.world.pos.y + 20.0f + Rand_CenteredFloat(120.0f);
+                        EffectSsDeadDb_Spawn(gPlayState, &pos, &sp7C, &sp7C, 100, 0, 255, 255, 255, 255, 0, 0, 255, 1, 9,
+                                             true);
+                    }
+                    Actor_Kill(&ik->actor);
+                }
+                *should = false;
+            }
+            break;
+        }
         }
     }
 }

--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -27,6 +27,7 @@ extern "C" {
 #include <overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.h>
 #include <overlays/actors/ovl_En_Ik/z_en_ik.h>
 #include <objects/object_gnd/object_gnd.h>
+#include <overlays/actors/ovl_Boss_Tw/z_boss_tw.h>
 extern SaveContext gSaveContext;
 extern PlayState* gPlayState;
 extern int32_t D_8011D3AC;
@@ -767,6 +768,23 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, void*
                     Actor_Kill(&ik->actor);
                 }
                 *should = false;
+            }
+            break;
+        }
+        case GI_VB_TWINROVA_DEATH_SCENE: {
+            BossTw* tw = static_cast<BossTw*>(opt);
+            if (CVarGetInteger("gTimeSavers.SkipCutscene.QuickBossDeaths", IS_RANDO || IS_BOSS_RUSH)) {
+                // Skip ahead to last part of the cutscene in rando
+                if (tw->work[CS_TIMER_2] == 10) {
+                    tw->work[CS_TIMER_2] = 860;
+                }
+                // Add separate timings for the "beam" that opens and closes around the sisters
+                // Needed because we skip ahead in cutscene timer value so it never gets called otherwise
+                if (tw->work[CS_TIMER_2] < 900) {
+                    Math_ApproachF(&tw->workf[UNK_F18], 255.0f, 0.1f, 5.0f);
+                } else if (tw->work[CS_TIMER_2] > 910) {
+                    Math_ApproachF(&tw->workf[UNK_F18], 0.0f, 1.0f, 3.0f);
+                }
             }
             break;
         }

--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -746,6 +746,7 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, void*
                 }
             }
             break;
+        }
         case GI_VB_NABOORU_KNUCKLE_DEATH_SCENE: {
             EnIk* ik = static_cast<EnIk*>(opt);
             if (CVarGetInteger("gTimeSavers.SkipCutscene.QuickBossDeaths", IS_RANDO)) {
@@ -768,7 +769,6 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, void*
                 *should = false;
             }
             break;
-        }
         }
     }
 }

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -581,6 +581,7 @@ void DrawEnhancementsMenu() {
                     CVarGetInteger("gTimeSavers.SkipCutscene.Story", IS_RANDO) &&
                     CVarGetInteger("gTimeSavers.SkipCutscene.LearnSong", IS_RANDO) &&
                     CVarGetInteger("gTimeSavers.SkipCutscene.BossIntro", IS_RANDO) &&
+                    CVarGetInteger("gTimeSavers.SkipCutscene.QuickBossDeaths", IS_RANDO) &&
                     CVarGetInteger("gTimeSavers.SkipCutscene.OnePoint", IS_RANDO) &&
                     CVarGetInteger("gTimeSavers.NoForcedDialog", IS_RANDO) &&
                     CVarGetInteger("gTimeSavers.SkipOwlInteractions", IS_RANDO) &&
@@ -592,6 +593,7 @@ void DrawEnhancementsMenu() {
                     CVarGetInteger("gTimeSavers.SkipCutscene.Story", IS_RANDO) ||
                     CVarGetInteger("gTimeSavers.SkipCutscene.LearnSong", IS_RANDO) ||
                     CVarGetInteger("gTimeSavers.SkipCutscene.BossIntro", IS_RANDO) ||
+                    CVarGetInteger("gTimeSavers.SkipCutscene.QuickBossDeaths", IS_RANDO) ||
                     CVarGetInteger("gTimeSavers.SkipCutscene.OnePoint", IS_RANDO) ||
                     CVarGetInteger("gTimeSavers.NoForcedDialog", IS_RANDO) ||
                     CVarGetInteger("gTimeSavers.SkipOwlInteractions", IS_RANDO) ||
@@ -608,6 +610,7 @@ void DrawEnhancementsMenu() {
                         CVarSetInteger("gTimeSavers.SkipCutscene.Story", 1);
                         CVarSetInteger("gTimeSavers.SkipCutscene.LearnSong", 1);
                         CVarSetInteger("gTimeSavers.SkipCutscene.BossIntro", 1);
+                        CVarSetInteger("gTimeSavers.SkipCutscene.QuickBossDeaths", 1);
                         CVarSetInteger("gTimeSavers.SkipCutscene.OnePoint", 1);
                         CVarSetInteger("gTimeSavers.NoForcedDialog", 1);
                         CVarSetInteger("gTimeSavers.SkipOwlInteractions", 1);
@@ -619,6 +622,7 @@ void DrawEnhancementsMenu() {
                         CVarSetInteger("gTimeSavers.SkipCutscene.Story", 0);
                         CVarSetInteger("gTimeSavers.SkipCutscene.LearnSong", 0);
                         CVarSetInteger("gTimeSavers.SkipCutscene.BossIntro", 0);
+                        CVarSetInteger("gTimeSavers.SkipCutscene.QuickBossDeaths", 0);
                         CVarSetInteger("gTimeSavers.SkipCutscene.OnePoint", 0);
                         CVarSetInteger("gTimeSavers.NoForcedDialog", 0);
                         CVarSetInteger("gTimeSavers.SkipOwlInteractions", 0);
@@ -633,6 +637,7 @@ void DrawEnhancementsMenu() {
                 UIWidgets::PaddedEnhancementCheckbox("Skip Story Cutscenes", "gTimeSavers.SkipCutscene.Story", false, false, false, "", UIWidgets::CheckboxGraphics::Cross, IS_RANDO);
                 UIWidgets::PaddedEnhancementCheckbox("Skip Song Cutscenes", "gTimeSavers.SkipCutscene.LearnSong", false, false, false, "", UIWidgets::CheckboxGraphics::Cross, IS_RANDO);
                 UIWidgets::PaddedEnhancementCheckbox("Skip Boss Introductions", "gTimeSavers.SkipCutscene.BossIntro", false, false, false, "", UIWidgets::CheckboxGraphics::Cross, IS_RANDO);
+                UIWidgets::PaddedEnhancementCheckbox("Quick Boss Deaths", "gTimeSavers.SkipCutscene.QuickBossDeaths", false, false, false, "", UIWidgets::CheckboxGraphics::Cross, IS_RANDO);
                 UIWidgets::PaddedEnhancementCheckbox("Skip One Point Cutscenes (Chests, Door Unlocks, etc)", "gTimeSavers.SkipCutscene.OnePoint", false, false, false, "", UIWidgets::CheckboxGraphics::Cross, IS_RANDO);
                 UIWidgets::PaddedEnhancementCheckbox("No Forced Dialog", "gTimeSavers.NoForcedDialog", false, false, false, "", UIWidgets::CheckboxGraphics::Cross, IS_RANDO);
                 UIWidgets::Tooltip("Prevent forced conversations with Navi or other NPCs");

--- a/soh/src/overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.h
+++ b/soh/src/overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.h
@@ -61,6 +61,23 @@ typedef enum {
     /* 13 */ GND_FLOAT_COUNT = 13
 } BossGanondrofF32Var;
 
+// Relocated from z_boss_ganondrof.c
+typedef enum {
+    /* 0 */ NOT_DEAD,
+    /* 1 */ DEATH_START,
+    /* 2 */ DEATH_THROES,
+    /* 3 */ DEATH_WARP,
+    /* 4 */ DEATH_SCREAM,
+    /* 5 */ DEATH_DISINTEGRATE,
+    /* 6 */ DEATH_FINISH
+} BossGanondrofDeathState;
+
+typedef enum {
+    /* 0 */ DEATH_SPASM,
+    /* 1 */ DEATH_LIMP,
+    /* 2 */ DEATH_HUNCHED
+} BossGanondrofDeathAction;
+
 typedef struct BossGanondrof {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ SkelAnime skelAnime;

--- a/soh/src/overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.h
+++ b/soh/src/overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.h
@@ -61,7 +61,7 @@ typedef enum {
     /* 13 */ GND_FLOAT_COUNT = 13
 } BossGanondrofF32Var;
 
-// Relocated from z_boss_ganondrof.c
+// SOH [Enhancements] Relocated from z_boss_ganondrof.c to use in time saver.
 typedef enum {
     /* 0 */ NOT_DEAD,
     /* 1 */ DEATH_START,

--- a/soh/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
+++ b/soh/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
@@ -5,6 +5,7 @@
 #include "overlays/actors/ovl_Door_Warp1/z_door_warp1.h"
 #include "soh/frame_interpolation.h"
 #include "soh/Enhancements/boss-rush/BossRush.h"
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #include <string.h>
 
@@ -2364,223 +2365,210 @@ void BossTw_DeathCSMsgSfx(BossTw* this, PlayState* play) {
     koumeAnim = 0;
     sp35 = 0;
 
-    // Skip ahead to last part of the cutscene in rando
-    if (this->work[CS_TIMER_2] == 10 && (IS_RANDO || IS_BOSS_RUSH)) {
-        this->work[CS_TIMER_2] = 860;
-    }
-
-    if (this->work[CS_TIMER_2] == 80) {
-        koumeAnim = 1;
-    }
+    if (GameInteractor_Should(GI_VB_TWINROVA_DEATH_SCENE, true, this)) {
+        if (this->work[CS_TIMER_2] == 80) {
+            koumeAnim = 1;
+        }
     
-    if (this->work[CS_TIMER_2] == 80) {
-        msgId2 = 0x604B;
-        sp35 = 50;
-    }
-
-    if (this->work[CS_TIMER_2] == 140) {
-        kotakeAnim = koumeAnim = 2;
-    }
-
-    if (this->work[CS_TIMER_2] == 170) {
-        kotakeAnim = 3;
-        sKotakePtr->work[YAW_TGT] = -0x4000;
-        sKotakePtr->rotateSpeed = 0.0f;
-        Audio_PlayActorSound2(&sKotakePtr->actor, NA_SE_EN_TWINROBA_SENSE);
-        msgId2 = 0x604C;
-    }
-
-    if (this->work[CS_TIMER_2] == 210) {
-        D_8094C874 = 30;
-    }
-
-    if (this->work[CS_TIMER_2] == 270) {
-        koumeAnim = 3;
-        sKoumePtr->work[YAW_TGT] = 0x4000;
-        sKoumePtr->rotateSpeed = 0.0f;
-        Audio_PlayActorSound2(&sKoumePtr->actor, NA_SE_EN_TWINROBA_SENSE);
-    }
-
-    if (this->work[CS_TIMER_2] == 290) {
-        msgId2 = 0x604D;
-        sp35 = 35;
-    }
-
-    if (this->work[CS_TIMER_2] == 350) {
-        koumeAnim = kotakeAnim = 2;
-        sKoumePtr->work[YAW_TGT] = sKotakePtr->work[YAW_TGT] = 0;
-        sKoumePtr->rotateSpeed = sKotakePtr->rotateSpeed = 0.0f;
-    }
-
-    if (this->work[CS_TIMER_2] == 380) {
-        koumeAnim = kotakeAnim = 3;
-    }
-
-    if (this->work[CS_TIMER_2] == 400) {
-        koumeAnim = kotakeAnim = 2;
-    }
-
-    if (this->work[CS_TIMER_2] == 430) {
-        koumeAnim = 4;
-        D_8094C874 = 435;
-        D_8094C878 = 1;
-    }
-
-    if (this->work[CS_TIMER_2] > 440 && this->work[CS_TIMER_2] < 860) {
-        func_80078884(NA_SE_EN_TWINROBA_FIGHT - SFX_FLAG);
-    }
-
-    if (this->work[CS_TIMER_2] == 430) {
-        msgId2 = 0x604E;
-    }
-
-    if (this->work[CS_TIMER_2] == 480) {
-        kotakeAnim = 4;
-        sKotakePtr->work[YAW_TGT] = -0x4000;
-    }
-
-    if (this->work[CS_TIMER_2] == 500) {
-        koumeAnim = 2;
-    }
-
-    if (this->work[CS_TIMER_2] == 480) {
-        msgId1 = 0x604F;
-    }
-
-    if (this->work[CS_TIMER_2] == 530) {
-        koumeAnim = 4;
-        sKoumePtr->work[YAW_TGT] = 0x4000;
-        D_8094C87A = 335;
-        D_8094C87E = 1;
-    }
-
-    if (this->work[CS_TIMER_2] == 530) {
-        msgId2 = 0x6050;
-    }
-
-    if (this->work[CS_TIMER_2] == 580) {
-        msgId1 = 0x6051;
-    }
-
-    if (this->work[CS_TIMER_2] == 620) {
-        msgId2 = 0x6052;
-    }
-
-    if (this->work[CS_TIMER_2] == 660) {
-        msgId1 = 0x6053;
-    }
-
-    if (this->work[CS_TIMER_2] == 700) {
-        msgId2 = 0x6054;
-    }
-
-    if (this->work[CS_TIMER_2] == 740) {
-        msgId1 = 0x6055;
-    }
-
-    if (this->work[CS_TIMER_2] == 780) {
-        msgId2 = 0x6056;
-    }
-
-    if (this->work[CS_TIMER_2] == 820) {
-        msgId1 = 0x6057;
-        Audio_QueueSeqCmd(0x1 << 28 | SEQ_PLAYER_BGM_MAIN << 24 | 0x5000FF);
-    }
-
-    if (this->work[CS_TIMER_2] == 860) {
-        koumeAnim = kotakeAnim = 3;
-    }
-
-    if (this->work[CS_TIMER_2] == 900) {
-        Audio_PlayActorSound2(&sKoumePtr->actor, NA_SE_EN_TWINROBA_DIE);
-        Audio_PlayActorSound2(&sKotakePtr->actor, NA_SE_EN_TWINROBA_DIE);
-    }
-
-    if (this->work[CS_TIMER_2] == 930) {
-        msgId2 = 0x6058;
-    }
-
-    if (msgId2 != 0) {
-        Message_StartTextbox(play, msgId2, NULL);
-
-        if (sp35) {
-            D_8094C876 = 10;
-            D_8094C874 = sp35;
-            D_8094C878 = 0;
+        if (this->work[CS_TIMER_2] == 80) {
+            msgId2 = 0x604B;
+            sp35 = 50;
         }
-    }
 
-    if (msgId1 != 0) {
-        Message_StartTextbox(play, msgId1, NULL);
-    }
-
-    switch (kotakeAnim) {
-        case 1:
-            Animation_MorphToLoop(&sKotakePtr->skelAnime, &gTwinrovaKotakeKoumeShakeHandAnim, -5.0f);
-            break;
-        case 2:
-            Animation_MorphToLoop(&sKotakePtr->skelAnime, &gTwinrovaKotakeKoumeFloatLookForwardAnim, -5.0f);
-            break;
-        case 3:
-            Animation_MorphToLoop(&sKotakePtr->skelAnime, &gTwinrovaKotakeKoumeFloatLookUpAnim, -5.0f);
-            break;
-        case 4:
-            Animation_MorphToLoop(&sKotakePtr->skelAnime, &gTwinrovaKotakeKoumeBickerAnim, -5.0f);
-            break;
-    }
-
-    switch (koumeAnim) {
-        case 1:
-            Animation_MorphToLoop(&sKoumePtr->skelAnime, &gTwinrovaKotakeKoumeShakeHandAnim, -5.0f);
-            break;
-        case 2:
-            Animation_MorphToLoop(&sKoumePtr->skelAnime, &gTwinrovaKotakeKoumeFloatLookForwardAnim, -5.0f);
-            break;
-        case 3:
-            Animation_MorphToLoop(&sKoumePtr->skelAnime, &gTwinrovaKotakeKoumeFloatLookUpAnim, -5.0f);
-            break;
-        case 4:
-            Animation_MorphToLoop(&sKoumePtr->skelAnime, &gTwinrovaKotakeKoumeBickerAnim, -5.0f);
-            break;
-    }
-
-    if (this->work[CS_TIMER_2] >= 120 && this->work[CS_TIMER_2] < 500) {
-        Math_ApproachF(&this->workf[UNK_F18], 255.0f, 0.1f, 5.0f);
-    }
-
-    // Add separate timings for the "beam" that opens and closes around the sisters
-    // Needed because we skip ahead in cutscene timer value so it never gets called otherwise
-    if (IS_RANDO || IS_BOSS_RUSH) {
-        if (this->work[CS_TIMER_2] < 900) {
-            Math_ApproachF(&this->workf[UNK_F18], 255.0f, 0.1f, 5.0f);
-        } else if (this->work[CS_TIMER_2] > 910) {
-            Math_ApproachF(&this->workf[UNK_F18], 0.0f, 1.0f, 3.0f);
+        if (this->work[CS_TIMER_2] == 140) {
+            kotakeAnim = koumeAnim = 2;
         }
-    }
 
-    if (this->work[CS_TIMER_2] >= 150) {
-        Math_ApproachF(&sKoumePtr->workf[UNK_F17], (Math_SinS(this->work[CS_TIMER_1] * 2000) * 0.05f) + 0.4f, 0.1f,
-                       0.01f);
-        Math_ApproachF(&sKotakePtr->workf[UNK_F17], (Math_CosS(this->work[CS_TIMER_1] * 1700) * 0.05f) + 0.4f, 0.1f,
-                       0.01f);
+        if (this->work[CS_TIMER_2] == 170) {
+            kotakeAnim = 3;
+            sKotakePtr->work[YAW_TGT] = -0x4000;
+            sKotakePtr->rotateSpeed = 0.0f;
+            Audio_PlayActorSound2(&sKotakePtr->actor, NA_SE_EN_TWINROBA_SENSE);
+            msgId2 = 0x604C;
+        }
 
-        if (this->work[CS_TIMER_2] >= 880) {
-            Math_ApproachF(&sKotakePtr->actor.world.pos.y, 2000.0f, 1.0f, this->actor.speedXZ);
-            Math_ApproachF(&sKoumePtr->actor.world.pos.y, 2000.0f, 1.0f, this->actor.speedXZ);
-            Math_ApproachF(&this->actor.speedXZ, 10.0f, 1.0f, 0.25f);
+        if (this->work[CS_TIMER_2] == 210) {
+            D_8094C874 = 30;
+        }
 
-            if (this->work[CS_TIMER_2] >= 930) {
-                Math_ApproachF(&this->workf[UNK_F19], 5.0f, 1.0f, 0.05f);
-                Math_ApproachF(&this->workf[UNK_F18], 0.0f, 1.0f, 3.0f);
+        if (this->work[CS_TIMER_2] == 270) {
+            koumeAnim = 3;
+            sKoumePtr->work[YAW_TGT] = 0x4000;
+            sKoumePtr->rotateSpeed = 0.0f;
+            Audio_PlayActorSound2(&sKoumePtr->actor, NA_SE_EN_TWINROBA_SENSE);
+        }
+
+        if (this->work[CS_TIMER_2] == 290) {
+            msgId2 = 0x604D;
+            sp35 = 35;
+        }
+
+        if (this->work[CS_TIMER_2] == 350) {
+            koumeAnim = kotakeAnim = 2;
+            sKoumePtr->work[YAW_TGT] = sKotakePtr->work[YAW_TGT] = 0;
+            sKoumePtr->rotateSpeed = sKotakePtr->rotateSpeed = 0.0f;
+        }
+
+        if (this->work[CS_TIMER_2] == 380) {
+            koumeAnim = kotakeAnim = 3;
+        }
+
+        if (this->work[CS_TIMER_2] == 400) {
+            koumeAnim = kotakeAnim = 2;
+        }
+
+        if (this->work[CS_TIMER_2] == 430) {
+            koumeAnim = 4;
+            D_8094C874 = 435;
+            D_8094C878 = 1;
+        }
+
+        if (this->work[CS_TIMER_2] > 440 && this->work[CS_TIMER_2] < 860) {
+            func_80078884(NA_SE_EN_TWINROBA_FIGHT - SFX_FLAG);
+        }
+
+        if (this->work[CS_TIMER_2] == 430) {
+            msgId2 = 0x604E;
+        }
+
+        if (this->work[CS_TIMER_2] == 480) {
+            kotakeAnim = 4;
+            sKotakePtr->work[YAW_TGT] = -0x4000;
+        }
+
+        if (this->work[CS_TIMER_2] == 500) {
+            koumeAnim = 2;
+        }
+
+        if (this->work[CS_TIMER_2] == 480) {
+            msgId1 = 0x604F;
+        }
+
+        if (this->work[CS_TIMER_2] == 530) {
+            koumeAnim = 4;
+            sKoumePtr->work[YAW_TGT] = 0x4000;
+            D_8094C87A = 335;
+            D_8094C87E = 1;
+        }
+
+        if (this->work[CS_TIMER_2] == 530) {
+            msgId2 = 0x6050;
+        }
+
+        if (this->work[CS_TIMER_2] == 580) {
+            msgId1 = 0x6051;
+        }
+
+        if (this->work[CS_TIMER_2] == 620) {
+            msgId2 = 0x6052;
+        }
+
+        if (this->work[CS_TIMER_2] == 660) {
+            msgId1 = 0x6053;
+        }
+
+        if (this->work[CS_TIMER_2] == 700) {
+            msgId2 = 0x6054;
+        }
+
+        if (this->work[CS_TIMER_2] == 740) {
+            msgId1 = 0x6055;
+        }
+
+        if (this->work[CS_TIMER_2] == 780) {
+            msgId2 = 0x6056;
+        }
+
+        if (this->work[CS_TIMER_2] == 820) {
+            msgId1 = 0x6057;
+            Audio_QueueSeqCmd(0x1 << 28 | SEQ_PLAYER_BGM_MAIN << 24 | 0x5000FF);
+        }
+
+        if (this->work[CS_TIMER_2] == 860) {
+            koumeAnim = kotakeAnim = 3;
+        }
+
+        if (this->work[CS_TIMER_2] == 900) {
+            Audio_PlayActorSound2(&sKoumePtr->actor, NA_SE_EN_TWINROBA_DIE);
+            Audio_PlayActorSound2(&sKotakePtr->actor, NA_SE_EN_TWINROBA_DIE);
+        }
+
+        if (this->work[CS_TIMER_2] == 930) {
+            msgId2 = 0x6058;
+        }
+
+        if (msgId2 != 0) {
+            Message_StartTextbox(play, msgId2, NULL);
+
+            if (sp35) {
+                D_8094C876 = 10;
+                D_8094C874 = sp35;
+                D_8094C878 = 0;
             }
+        }
 
-            Audio_PlayActorSound2(&this->actor, NA_SE_EV_GOTO_HEAVEN - SFX_FLAG);
-        } else {
-            f32 yTarget = Math_CosS(this->work[CS_TIMER_2] * 1700) * 4.0f;
-            Math_ApproachF(&sKotakePtr->actor.world.pos.y, 20.0f + (263.0f + yTarget), 0.1f, this->actor.speedXZ);
-            yTarget = Math_SinS(this->work[CS_TIMER_2] * 1500) * 4.0f;
-            Math_ApproachF(&sKoumePtr->actor.world.pos.y, 20.0f + (263.0f + yTarget), 0.1f, this->actor.speedXZ);
-            Math_ApproachF(&this->actor.speedXZ, 1.0f, 1.0f, 0.05f);
+        if (msgId1 != 0) {
+            Message_StartTextbox(play, msgId1, NULL);
+        }
+
+        switch (kotakeAnim) {
+            case 1:
+                Animation_MorphToLoop(&sKotakePtr->skelAnime, &gTwinrovaKotakeKoumeShakeHandAnim, -5.0f);
+                break;
+            case 2:
+                Animation_MorphToLoop(&sKotakePtr->skelAnime, &gTwinrovaKotakeKoumeFloatLookForwardAnim, -5.0f);
+                break;
+            case 3:
+                Animation_MorphToLoop(&sKotakePtr->skelAnime, &gTwinrovaKotakeKoumeFloatLookUpAnim, -5.0f);
+                break;
+            case 4:
+                Animation_MorphToLoop(&sKotakePtr->skelAnime, &gTwinrovaKotakeKoumeBickerAnim, -5.0f);
+                break;
+        }
+
+        switch (koumeAnim) {
+            case 1:
+                Animation_MorphToLoop(&sKoumePtr->skelAnime, &gTwinrovaKotakeKoumeShakeHandAnim, -5.0f);
+                break;
+            case 2:
+                Animation_MorphToLoop(&sKoumePtr->skelAnime, &gTwinrovaKotakeKoumeFloatLookForwardAnim, -5.0f);
+                break;
+            case 3:
+                Animation_MorphToLoop(&sKoumePtr->skelAnime, &gTwinrovaKotakeKoumeFloatLookUpAnim, -5.0f);
+                break;
+            case 4:
+                Animation_MorphToLoop(&sKoumePtr->skelAnime, &gTwinrovaKotakeKoumeBickerAnim, -5.0f);
+                break;
+        }
+
+        if (this->work[CS_TIMER_2] >= 120 && this->work[CS_TIMER_2] < 500) {
+            Math_ApproachF(&this->workf[UNK_F18], 255.0f, 0.1f, 5.0f);
+        }
+
+        if (this->work[CS_TIMER_2] >= 150) {
+            Math_ApproachF(&sKoumePtr->workf[UNK_F17], (Math_SinS(this->work[CS_TIMER_1] * 2000) * 0.05f) + 0.4f, 0.1f,
+                        0.01f);
+            Math_ApproachF(&sKotakePtr->workf[UNK_F17], (Math_CosS(this->work[CS_TIMER_1] * 1700) * 0.05f) + 0.4f, 0.1f,
+                        0.01f);
+
+            if (this->work[CS_TIMER_2] >= 880) {
+                Math_ApproachF(&sKotakePtr->actor.world.pos.y, 2000.0f, 1.0f, this->actor.speedXZ);
+                Math_ApproachF(&sKoumePtr->actor.world.pos.y, 2000.0f, 1.0f, this->actor.speedXZ);
+                Math_ApproachF(&this->actor.speedXZ, 10.0f, 1.0f, 0.25f);
+
+                if (this->work[CS_TIMER_2] >= 930) {
+                    Math_ApproachF(&this->workf[UNK_F19], 5.0f, 1.0f, 0.05f);
+                    Math_ApproachF(&this->workf[UNK_F18], 0.0f, 1.0f, 3.0f);
+                }
+
+                Audio_PlayActorSound2(&this->actor, NA_SE_EV_GOTO_HEAVEN - SFX_FLAG);
+            } else {
+                f32 yTarget = Math_CosS(this->work[CS_TIMER_2] * 1700) * 4.0f;
+                Math_ApproachF(&sKotakePtr->actor.world.pos.y, 20.0f + (263.0f + yTarget), 0.1f, this->actor.speedXZ);
+                yTarget = Math_SinS(this->work[CS_TIMER_2] * 1500) * 4.0f;
+                Math_ApproachF(&sKoumePtr->actor.world.pos.y, 20.0f + (263.0f + yTarget), 0.1f, this->actor.speedXZ);
+                Math_ApproachF(&this->actor.speedXZ, 1.0f, 1.0f, 0.05f);
+            }
         }
     }
 }

--- a/soh/src/overlays/actors/ovl_En_Ik/z_en_ik.c
+++ b/soh/src/overlays/actors/ovl_En_Ik/z_en_ik.c
@@ -1439,28 +1439,10 @@ void func_80A781CC(Actor* thisx, PlayState* play) {
     if (!Play_InCsMode(play)) {
         this->actor.update = EnIk_Update;
         this->actor.draw = EnIk_Draw;
-        // Don't initiate nabooru defeat CS in rando
-        if (!(IS_RANDO)) {
+        if (GameInteractor_Should(GI_VB_NABOORU_KNUCKLE_DEATH_SCENE, true, this)) {
             Cutscene_SetSegment(play, gSpiritBossNabooruKnuckleDefeatCs);
             gSaveContext.cutsceneTrigger = 1;
             Actor_SetScale(&this->actor, 0.01f);
-        } else {
-        // Because no CS in rando, we hide the death of the knuckle by spawning flames and kill the actor
-            if ((this->actor.colChkInfo.health <= 10)) {
-                s32 i;
-                Vec3f pos;
-                Vec3f sp7C = { 0.0f, 0.5f, 0.0f };
-                int flameAmount = 100;
-
-                for (i = flameAmount; i >= 0; i--) {
-                    pos.x = this->actor.world.pos.x + Rand_CenteredFloat(120.0f);
-                    pos.z = this->actor.world.pos.z + Rand_CenteredFloat(120.0f);
-                    pos.y = this->actor.world.pos.y + 20.0f + Rand_CenteredFloat(120.0f);
-                    EffectSsDeadDb_Spawn(play, &pos, &sp7C, &sp7C, 100, 0, 255, 255, 255, 255, 0, 0, 255, 1, 9,
-                                            true);
-                }
-                Actor_Kill(&this->actor);
-            }
         }
         Flags_SetEventChkInf(EVENTCHKINF_FINISHED_NABOORU_BATTLE);
         func_80A7735C(this, play);


### PR DESCRIPTION
This one is a bit weird because the way we implemented it originally only added to the existing sequence, there's not really a "if rando do this else do this" type of setup like there is for other things. We were always running all the vanilla code in rando. As such, the case statement for this one doesn't have `*should = false` anywhere, and this is intentional.

Blocked by #120 

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1455130760.zip)
  - [soh-windows.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1455152202.zip)
  - [soh-wiiu.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1455153638.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1455153963.zip)
  - [soh-linux-performance.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1455158345.zip)
  - [soh-switch.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1455161035.zip)
  - [soh-mac.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1455165546.zip)
<!--- section:artifacts:end -->