### PR TITLE
explicitly include unordered_map header

### DIFF
--- a/soh/soh/Enhancements/game-interactor/GameInteractor.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor.h
@@ -420,6 +420,7 @@ void GameInteractor_SetTriforceHuntCreditsWarpActive(uint8_t state);
 
 #ifdef __cplusplus
 #include <thread>
+#include <unordered_map>
 #include <vector>
 #include <functional>
 #include <string>


### PR DESCRIPTION
explicitly include unordered_map header, as it was implicitly included by nlohmann json if you have REMOTE_CONTROL enabled, but building with it off would fail.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1464698363.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1464744072.zip)
  - [soh-wiiu.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1464750114.zip)
  - [soh-switch.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1464759275.zip)
  - [soh-linux-performance.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1464760034.zip)
  - [soh-mac.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/1464773167.zip)
<!--- section:artifacts:end -->