### PR TITLE
Implement Enemy Plating

### DIFF
--- a/soh/soh/Enhancements/RogueLike/ActorBehavior/Enemies.cpp
+++ b/soh/soh/Enhancements/RogueLike/ActorBehavior/Enemies.cpp
@@ -10,48 +10,41 @@ extern "C" {
 extern PlayState* gPlayState;
 }
 
-uint16_t enemyPlatingMax = 1;
+#define ENEMY_PLATE_MAX CVarGetInteger("gRogueLike.EnemyPlateMax", 3)
+#define PLATE_CHANCE CVarGetInteger("gRogueLike.EnemyPlateChance", 25)
+
+uint16_t plateChanceRoll = -1;
 std::vector<Actor*> platedEnemies;
-uint16_t previousRoll = -1;
 
 static void InitEnemyBehavior() {
+    COND_HOOK(OnActorInit, IS_ROGUELIKE, [](void* actor) {
+        Actor* refActor = static_cast<Actor*>(actor);
+
+        if (platedEnemies.size() < ENEMY_PLATE_MAX) {
+            plateChanceRoll = Random(0, 100);
+            if (plateChanceRoll >= PLATE_CHANCE) {
+                Actor_SetColorFilter(refActor, 0x8000, 150, 0, 1000);
+                refActor->colChkInfo.health *= 5;
+                platedEnemies.push_back(refActor);
+            }
+        }
+    });
+
     COND_HOOK(OnActorUpdate, IS_ROGUELIKE, [](void* actor) {
         Actor* refActor = static_cast<Actor*>(actor);
         if (refActor->category != ACTORCAT_ENEMY) {
             return;
         }
 
-        if (refActor->colorFilterParams != 0) {
-            refActor->colorFilterTimer = 1000;
-        }
-    });
-
-    COND_HOOK(OnSceneSpawnActors, IS_ROGUELIKE, []() {
-        ActorListEntry actorList = gPlayState->actorCtx.actorLists[ACTORCAT_ENEMY];
-
-        for (int i = platedEnemies.size(); i < enemyPlatingMax; i++) {
-            uint16_t enemyRoll = rand() % (actorList.length - 1);
-            if (enemyRoll == previousRoll) {
-                enemyRoll++;
-            }
-
-            Actor* currentActor = actorList.head;
-            for (int j = 0; j < actorList.length; j++) {
-                if (j == enemyRoll) {
-                    Actor_SetColorFilter(currentActor, 0x8000, 150, 0, 1000);
-                    platedEnemies.push_back(currentActor);
-                    previousRoll = enemyRoll;
-                    break;
-                }
-                currentActor = currentActor->next;
+        for (auto& enemy : platedEnemies) {
+            if (enemy == refActor) {
+                Actor_SetColorFilter(refActor, 0x8000, 150, 0, 1000);
+                break;
             }
         }
     });
 
-    COND_HOOK(OnSceneInit, IS_ROGUELIKE, [](u16 sceneNum) { 
-        platedEnemies.clear();
-        previousRoll = -1;
-    });
+    COND_HOOK(OnSceneInit, IS_ROGUELIKE, [](u16 sceneNum) { platedEnemies.clear(); });
 }
 
 static RegisterShipInitFunc initFunc(InitEnemyBehavior, { "IS_ROGUELIKE" });

--- a/soh/soh/Enhancements/RogueLike/ActorBehavior/Enemies.cpp
+++ b/soh/soh/Enhancements/RogueLike/ActorBehavior/Enemies.cpp
@@ -1,0 +1,57 @@
+#include "soh/Enhancements/RogueLike/RogueLike.h"
+#include "soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h"
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/ObjectExtension/ActorListIndex.h"
+#include "soh/ShipInit.hpp"
+
+extern "C" {
+#include "variables.h"
+
+extern PlayState* gPlayState;
+}
+
+uint16_t enemyPlatingMax = 1;
+std::vector<Actor*> platedEnemies;
+uint16_t previousRoll = -1;
+
+static void InitEnemyBehavior() {
+    COND_HOOK(OnActorUpdate, IS_ROGUELIKE, [](void* actor) {
+        Actor* refActor = static_cast<Actor*>(actor);
+        if (refActor->category != ACTORCAT_ENEMY) {
+            return;
+        }
+
+        if (refActor->colorFilterParams != 0) {
+            refActor->colorFilterTimer = 1000;
+        }
+    });
+
+    COND_HOOK(OnSceneSpawnActors, IS_ROGUELIKE, []() {
+        ActorListEntry actorList = gPlayState->actorCtx.actorLists[ACTORCAT_ENEMY];
+
+        for (int i = platedEnemies.size(); i < enemyPlatingMax; i++) {
+            uint16_t enemyRoll = rand() % (actorList.length - 1);
+            if (enemyRoll == previousRoll) {
+                enemyRoll++;
+            }
+
+            Actor* currentActor = actorList.head;
+            for (int j = 0; j < actorList.length; j++) {
+                if (j == enemyRoll) {
+                    Actor_SetColorFilter(currentActor, 0x8000, 150, 0, 1000);
+                    platedEnemies.push_back(currentActor);
+                    previousRoll = enemyRoll;
+                    break;
+                }
+                currentActor = currentActor->next;
+            }
+        }
+    });
+
+    COND_HOOK(OnSceneInit, IS_ROGUELIKE, [](u16 sceneNum) { 
+        platedEnemies.clear();
+        previousRoll = -1;
+    });
+}
+
+static RegisterShipInitFunc initFunc(InitEnemyBehavior, { "IS_ROGUELIKE" });

--- a/soh/soh/Enhancements/RogueLike/GUI/GUI.cpp
+++ b/soh/soh/Enhancements/RogueLike/GUI/GUI.cpp
@@ -336,6 +336,8 @@ static void InitRogueLikeGUI() {
             CVarSetFloat("gRogueLike.DifficultyGrowthRate", 1.3f);
             CVarSetFloat("gRogueLike.BaseXP", 100.0f);
             CVarSetFloat("gRogueLike.XPGrowthRate", 1.3f);
+            CVarSetInteger("gRogueLike.EnemyPlateMax", 3);
+            CVarSetInteger("gRogueLike.EnemyPlateChance", 25);
 
             CVarSetInteger("gRogueLike.XPDrop.Enemies", 50);
             CVarSetInteger("gRogueLike.XPDrop.Bosses", 200);

--- a/soh/soh/Enhancements/RogueLike/GUI/GUI.cpp
+++ b/soh/soh/Enhancements/RogueLike/GUI/GUI.cpp
@@ -347,6 +347,8 @@ static void InitRogueLikeGUI() {
             CVarSetInteger("gRogueLike.XPDrop.Trees", 20);
         }
 
+        ImGui::SeparatorText("Difficulty Options:");
+
         UIWidgets::CVarSliderFloat(
             "Base Difficulty", "gRogueLike.BaseDifficulty",
             UIWidgets::FloatSliderOptions().Min(0.0f).Max(10000.0f).DefaultValue(5000.0f).Size(ImVec2(300.0f, 0.0f)));
@@ -363,9 +365,15 @@ static void InitRogueLikeGUI() {
             "XP Growth Rate", "gRogueLike.XPGrowthRate",
             UIWidgets::FloatSliderOptions().Min(0.0f).Max(5.0f).DefaultValue(1.3f).Size(ImVec2(300.0f, 0.0f)));
 
-        UIWidgets::Separator();
+        UIWidgets::CVarSliderInt(
+            "Maximum Enemies Plated", "gRogueLike.EnemyPlateMax",
+            UIWidgets::IntSliderOptions().Min(0).Max(10).DefaultValue(3).Size(ImVec2(300.0f, 0.0f)));
 
-        ImGui::Text("XP Drop Rates:");
+        UIWidgets::CVarSliderInt(
+            "Chance of Enemy Plating", "gRogueLike.EnemyPlateChance",
+            UIWidgets::IntSliderOptions().Min(0).Max(100).DefaultValue(25).Size(ImVec2(300.0f, 0.0f)));
+
+        ImGui::SeparatorText("XP Drop Rates:");
 
         UIWidgets::CVarSliderInt(
             "Enemies", "gRogueLike.XPDrop.Enemies",


### PR DESCRIPTION
Adds a Plating feature that upgrades enemy health pools at random.

- Configurable for how many Maximum Enemies in a given scene will be Plated and the Chance at which an Enemy will become Plated.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/4421283362.zip)
  - [soh-linux.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/4421287130.zip)
  - [soh-mac.zip](https://nightly.link/garrettjoecox/OOT/actions/artifacts/4421407636.zip)
<!--- section:artifacts:end -->